### PR TITLE
feat: Spring REST Docs 설정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Make application.properties
         run: |
           mkdir ./src/main/resources
-          mkdir ./src/test/resources
           echo "${{ secrets.PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
           echo "${{ secrets.LOCAL_PROPERTIES }}" | base64 --decode > src/main/resources/application-local.yml
           echo "${{ secrets.TEST_PROPERTIES }}" | base64 --decode > src/test/resources/application.yml

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,64 @@
+= 빨리 잡아! API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+== API
+
+=== link:member/member-api.html[회원 API, window=blank]
+
+=== link:product/accommodation-api.html[숙소 API, window=blank]
+
+=== link:room/room-api.html[객실 API, window=blank]
+
+=== link:reservation/reservation-api.html[예약 API, window=blank]
+
+=== link:coupon/reservation-api.html[쿠폰 API, window=blank]
+
+== API Common Response
+
+[[overview-status-code]]
+=== 1. HTTP Status Code
+
+|===
+| Status code | Useage
+| `200 OK` | 요청을 성공적으로 수행
+| `201 Created` | 생성 요청 (ex: 여행 등록)을 성공적으로 수행
+| `400 Bad Request` | API 에 기술되어 있는 요구사항에 부적합 시 발생
+| `401 Unauthorized` | 해당 API에 대한 인증 정보가 없는 경우 발생
+| `403 Forbiddon` | 해당 API에 대한 권한이 없는 경우 발생
+| `404 NotFound` | 지원하지 않는 API 경로로 요청 시 발생
+| `500 Internal Server Error` | 내부 서버 에러
+|===
+
+=== 2. Service Error Code
+
+|===
+| Status code | Error code | Useage
+| `400 Bad Request` | 1000 | 회원 가입 시 이메일이 중복된 경우 발생
+| `401 Unauthorized` | 1001 | 리프레시 토큰이 유효하지 않는 경우 발생
+| `401 Unauthorized` | 1002 | 해당 회원이 이미 로그아웃한 경우 발생
+| `400 Bad Request` | 1003 | 로그인 시 이메일이 틀린 경우 발생
+| `400 Bad Request` | 1004 | 로그인 시 비밀번호가 틀린 경우 발생
+| `404 NotFound` | 1005 | 회원 정보를 찾을 수 없는 경우 발생
+| `404 NotFound` | 2000 | 숙소 정보를 찾을 수 없는 경우 발생
+| `400 Bad Request` | 2001 | 예약 불가능한 객실인 경우 발생
+| `404 NotFound` | 2002 | 객실 정보를 찾을 수 없는 경우 발생
+| `400 Bad Request` | 3000 | 결제를 실패한 경우 발생
+| `400 Bad Request` | 3001 | 결제 시 선택한 쿠폰이 유효하지 않는 경우 발생
+| `400 Bad Request` | 3002 | 예약 선점 기한이 만료되었거나, 잘못된 예약 요청인 경우 발생
+| `400 Bad Request` | 3003 | 예약 숙소 정보를 찾을 수 없는 경우 발생
+| `400 Bad Request` | 3004 | 방문자 성함이 유효하지 않는 경우 발생
+| `400 Bad Request` | 3005 | 방문자 전화번호가 유효하지 않는 경우 발생
+| `400 Bad Request` | 4000 | 쿠폰 정보를 찾을 수 없는 경우 발생
+| `500 Internal Server Error` | 5000 | 오픈 API 이용 중 오류가 생긴 경우 발생
+| `404 NotFound` | 5001 | 오픈 API에서 가져온 숙소 데이터에서 필요한 정보를 찾을 수 없는 경우 발생
+| `500 Internal Server Error` | 6000 | DB 에러
+| `400 Bad Request` | 6001 | Request Body가 유효하지 않는 경우 발생
+| `500 Internal Server Error` | 6002 | 서버 에러
+| `400 Bad Request` | 6003 | 날짜 데이터가 유효하지 않는 경우 발생
+|===

--- a/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsConfig.java
+++ b/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package com.backoffice.upjuyanolja.global.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler restDocumentationResultHandler() {
+        return MockMvcRestDocumentation.document(
+            "{class-name}/{method-name}",
+            Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+            Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsSupport.java
+++ b/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsSupport.java
@@ -51,7 +51,12 @@ public abstract class RestDocsSupport {
             .build();
     }
 
-    protected FieldDescriptor[] responseCommon() {
+    protected FieldDescriptor[] successResponseCommon() {
+        return new FieldDescriptor[]{
+            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")};
+    }
+
+    protected FieldDescriptor[] failResponseCommon() {
         return new FieldDescriptor[]{
             fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
             fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")};

--- a/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsSupport.java
+++ b/src/test/java/com/backoffice/upjuyanolja/global/config/RestDocsSupport.java
@@ -1,0 +1,59 @@
+package com.backoffice.upjuyanolja.global.config;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Disabled
+@SpringBootTest
+@ExtendWith({RestDocumentationExtension.class})
+@Import(RestDocsConfig.class)
+public abstract class RestDocsSupport {
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDoc;
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected WebApplicationContext context;
+
+    @BeforeEach
+    public void setup(RestDocumentationContextProvider restDocumentationContextProvider) {
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(documentationConfiguration(restDocumentationContextProvider))
+            .alwaysDo(print())
+            .alwaysDo(restDoc)
+            .apply(springSecurity())
+            .addFilters(new CharacterEncodingFilter("UTF-8", true))
+            .build();
+    }
+
+    protected FieldDescriptor[] responseCommon() {
+        return new FieldDescriptor[]{
+            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")};
+    }
+}

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,10 @@
+==== Path Parameters
+|===
+|Name|Description|Optional|Constraints
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{constraints}}{{/constraints}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,10 @@
+==== Query Parameters
+|===
+|Name|Description|Optional|Constraints
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{constraints}}{{/constraints}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,11 @@
+==== Request Fields
+|===
+|Path|Description|Type|Optional|Constraints
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}Optional{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraints}}{{constraints}}{{/constraints}}{{/tableCellContent}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,10 @@
+==== Response Fields
+|===
+|Path|Description|Type|Optional
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+{{/fields}}
+|===


### PR DESCRIPTION
### 💡Motivation
- Spring REST Docs를 활용한 문서화가 용이하도록 설정이 필요합니다. 

### 📌Changes
- Snippet Template 구현
- Spring REST Docs 파일 핸들러 설정 추가
- Spring REST Docs 설정 및 테스트 셋업

### 🫱🏻‍🫲🏻To Reviewers
- 문서화를 위한 Spring REST Docs 테스트를 작성하실 때 RestDocsSupport 클래스를 상속 받으시고, responseCommon() 메서드를 활용하시면 조금 더 간편하게 작성이 가능합니다. 😊

closes #27 