### PR TITLE
feat: 보유 숙소 목록 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/accommodation/accommodation-api.adoc
+++ b/src/docs/asciidoc/accommodation/accommodation-api.adoc
@@ -31,9 +31,9 @@ include::{snippets}/accommodation-controller-docs-test/register-accommodation/re
 
 === HttpRequest
 
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/http-request.adoc[]
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/http-request.adoc[]
 
 === HttpResponse
 
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/http-response.adoc[]
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/response-fields.adoc[]
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/http-response.adoc[]
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/response-fields.adoc[]

--- a/src/docs/asciidoc/accommodation/accommodation-api.adoc
+++ b/src/docs/asciidoc/accommodation/accommodation-api.adoc
@@ -23,3 +23,17 @@ include::{snippets}/accommodation-controller-docs-test/register-accommodation/re
 
 include::{snippets}/accommodation-controller-docs-test/register-accommodation/http-response.adoc[]
 include::{snippets}/accommodation-controller-docs-test/register-accommodation/response-fields.adoc[]
+
+[[Get-Accommodation-Ownership]]
+== 보유 숙소 목록 조회
+
+보유 숙소 목록 조회 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/http-request.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/http-response.adoc[]
+include::{snippets}/accommodation-controller-docs-test/get-accommodation-names/response-fields.adoc[]

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
@@ -3,8 +3,9 @@ package com.backoffice.upjuyanolja.domain.accommodation.controller;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationDetailResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationPageResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.service.AccommodationService;
+import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationCommandUseCase;
 import com.backoffice.upjuyanolja.global.common.response.ApiResponse;
 import com.backoffice.upjuyanolja.global.common.response.ApiResponse.SuccessResponse;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
@@ -33,8 +34,24 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AccommodationController {
 
-    private final AccommodationService accommodationService;
+    private final AccommodationCommandUseCase accommodationCommandUseCase;
     private final SecurityUtil securityUtil;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<AccommodationInfoResponse>> registerAccommodation(
+        @Valid @RequestBody AccommodationRegisterRequest accommodationRegisterRequest
+    ) {
+        log.info("POST /api/accommodations");
+
+        return ApiResponse.success(HttpStatus.CREATED,
+            SuccessResponse.<AccommodationInfoResponse>builder()
+                .message("성공적으로 숙소를 등록했습니다.")
+                .data(accommodationCommandUseCase.createAccommodation
+                    (securityUtil.getCurrentMemberId(), accommodationRegisterRequest)
+                )
+                .build()
+        );
+    }
 
     @GetMapping
     public ResponseEntity<SuccessResponse<AccommodationPageResponse>> getAccommodations(
@@ -48,7 +65,7 @@ public class AccommodationController {
     ) {
         log.info("GET /api/accommodations");
 
-        AccommodationPageResponse response = accommodationService.findAccommodations(
+        AccommodationPageResponse response = accommodationCommandUseCase.findAccommodations(
             category, type, onlyHasCoupon, keyword, pageable
         );
         return ApiResponse.success(
@@ -68,7 +85,7 @@ public class AccommodationController {
     ) {
         log.info("GET /api/accommodations/{accommodationId}");
 
-        AccommodationDetailResponse response = accommodationService.findAccommodationWithRooms(
+        AccommodationDetailResponse response = accommodationCommandUseCase.findAccommodationWithRooms(
             accommodationId, startDate, endDate
         );
         return ApiResponse.success(
@@ -80,16 +97,15 @@ public class AccommodationController {
         );
     }
 
-    @PostMapping
-    public ResponseEntity<SuccessResponse<AccommodationInfoResponse>> registerAccommodation(
-        @Valid @RequestBody AccommodationRegisterRequest accommodationRegisterRequest
-    ) {
-        return ApiResponse.success(HttpStatus.CREATED,
-            SuccessResponse.<AccommodationInfoResponse>builder()
-                .message("성공적으로 숙소를 등록했습니다.")
-                .data(accommodationService.createAccommodation
-                    (securityUtil.getCurrentMemberId(), accommodationRegisterRequest)
-                )
+    @GetMapping("/backoffice")
+    public ResponseEntity<SuccessResponse<AccommodationOwnershipResponse>> getAccommodationNames() {
+        log.info("GET /api/accommodations/backoffice");
+
+        return ApiResponse.success(HttpStatus.OK,
+            SuccessResponse.<AccommodationOwnershipResponse>builder()
+                .message("성공적으로 보유 숙소 목록을 조회했습니다.")
+                .data(accommodationCommandUseCase
+                    .getAccommodationNames(securityUtil.getCurrentMemberId()))
                 .build()
         );
     }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
@@ -98,14 +98,14 @@ public class AccommodationController {
     }
 
     @GetMapping("/backoffice")
-    public ResponseEntity<SuccessResponse<AccommodationOwnershipResponse>> getAccommodationNames() {
+    public ResponseEntity<SuccessResponse<AccommodationOwnershipResponse>> getAccommodationOwnership() {
         log.info("GET /api/accommodations/backoffice");
 
         return ApiResponse.success(HttpStatus.OK,
             SuccessResponse.<AccommodationOwnershipResponse>builder()
                 .message("성공적으로 보유 숙소 목록을 조회했습니다.")
                 .data(accommodationCommandUseCase
-                    .getAccommodationNames(securityUtil.getCurrentMemberId()))
+                    .getAccommodationOwnership(securityUtil.getCurrentMemberId()))
                 .build()
         );
     }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/dto/response/AccommodationNameResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/dto/response/AccommodationNameResponse.java
@@ -1,0 +1,18 @@
+package com.backoffice.upjuyanolja.domain.accommodation.dto.response;
+
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
+import lombok.Builder;
+
+@Builder
+public record AccommodationNameResponse(
+    long id,
+    String name
+) {
+
+    public static AccommodationNameResponse of(Accommodation accommodation) {
+        return AccommodationNameResponse.builder()
+            .id(accommodation.getId())
+            .name(accommodation.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/dto/response/AccommodationOwnershipResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/dto/response/AccommodationOwnershipResponse.java
@@ -1,0 +1,11 @@
+package com.backoffice.upjuyanolja.domain.accommodation.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AccommodationOwnershipResponse(
+    List<AccommodationNameResponse> accommodations
+) {
+
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/repository/AccommodationOwnershipRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/repository/AccommodationOwnershipRepository.java
@@ -1,9 +1,12 @@
 package com.backoffice.upjuyanolja.domain.accommodation.repository;
 
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwnership;
+import com.backoffice.upjuyanolja.domain.member.entity.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AccommodationOwnershipRepository extends
     JpaRepository<AccommodationOwnership, Long> {
 
+    List<AccommodationOwnership> findAllByMember(Member member);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationCommandService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationCommandService.java
@@ -88,7 +88,7 @@ public class AccommodationCommandService implements AccommodationCommandUseCase 
 
     @Override
     @Transactional(readOnly = true)
-    public AccommodationOwnershipResponse getAccommodationNames(long memberId) {
+    public AccommodationOwnershipResponse getAccommodationOwnership(long memberId) {
         Member member = memberGetService.getMemberById(memberId);
         List<AccommodationOwnership> ownerships = accommodationQueryUseCase
             .getOwnershipByMember(member);

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationQueryService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationQueryService.java
@@ -40,6 +40,7 @@ public class AccommodationQueryService implements AccommodationQueryUseCase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Accommodation getAccommodationById(long accommodationId) {
         return accommodationRepository.findById(accommodationId)
             .orElseThrow(AccommodationNotFoundException::new);
@@ -54,11 +55,13 @@ public class AccommodationQueryService implements AccommodationQueryUseCase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<AccommodationOwnership> getOwnershipByMember(Member member) {
         return accommodationOwnershipRepository.findAllByMember(member);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Category getCategoryByName(String name) {
         return categoryRepository.findCategoryByName(name)
             .orElseThrow(WrongCategoryException::new);

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationQueryService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationQueryService.java
@@ -1,0 +1,71 @@
+package com.backoffice.upjuyanolja.domain.accommodation.service;
+
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationImage;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwnership;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Category;
+import com.backoffice.upjuyanolja.domain.accommodation.exception.AccommodationNotFoundException;
+import com.backoffice.upjuyanolja.domain.accommodation.exception.WrongCategoryException;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationImageRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationOwnershipRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.CategoryRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationQueryUseCase;
+import com.backoffice.upjuyanolja.domain.member.entity.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AccommodationQueryService implements AccommodationQueryUseCase {
+
+    private final AccommodationRepository accommodationRepository;
+    private final AccommodationOwnershipRepository accommodationOwnershipRepository;
+    private final AccommodationImageRepository accommodationImageRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Accommodation saveAccommodation(AccommodationSaveRequest request) {
+        return accommodationRepository.save(Accommodation.builder()
+            .name(request.name())
+            .address(request.address())
+            .description(request.description())
+            .category(request.category())
+            .thumbnail(request.thumbnail())
+            .option(request.option())
+            .build());
+    }
+
+    @Override
+    public Accommodation getAccommodationById(long accommodationId) {
+        return accommodationRepository.findById(accommodationId)
+            .orElseThrow(AccommodationNotFoundException::new);
+    }
+
+    @Override
+    public AccommodationOwnership saveOwnership(Member member, Accommodation accommodation) {
+        return accommodationOwnershipRepository.save(AccommodationOwnership.builder()
+            .accommodation(accommodation)
+            .member(member)
+            .build());
+    }
+
+    @Override
+    public List<AccommodationOwnership> getOwnershipByMember(Member member) {
+        return accommodationOwnershipRepository.findAllByMember(member);
+    }
+
+    @Override
+    public Category getCategoryByName(String name) {
+        return categoryRepository.findCategoryByName(name)
+            .orElseThrow(WrongCategoryException::new);
+    }
+
+    @Override
+    public List<AccommodationImage> saveAllImages(List<AccommodationImage> images) {
+        return accommodationImageRepository.saveAll(images);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
@@ -1,0 +1,33 @@
+package com.backoffice.upjuyanolja.domain.accommodation.service.usecase;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationDetailResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationPageResponse;
+import java.time.LocalDate;
+import org.springframework.data.domain.Pageable;
+
+public interface AccommodationCommandUseCase {
+
+    AccommodationInfoResponse createAccommodation(
+        long memberId,
+        AccommodationRegisterRequest request
+    );
+
+    AccommodationPageResponse findAccommodations(
+        String Category,
+        String type,
+        boolean onlyHasCoupon,
+        String keyword,
+        Pageable pageable
+    );
+
+    AccommodationDetailResponse findAccommodationWithRooms(
+        Long accommodationId,
+        LocalDate startDate,
+        LocalDate endDate
+    );
+
+    AccommodationOwnershipResponse getAccommodationNames(long memberId);
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
@@ -29,5 +29,5 @@ public interface AccommodationCommandUseCase {
         LocalDate endDate
     );
 
-    AccommodationOwnershipResponse getAccommodationNames(long memberId);
+    AccommodationOwnershipResponse getAccommodationOwnership(long memberId);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationQueryUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationQueryUseCase.java
@@ -1,0 +1,38 @@
+package com.backoffice.upjuyanolja.domain.accommodation.service.usecase;
+
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationImage;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwnership;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Address;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Category;
+import com.backoffice.upjuyanolja.domain.member.entity.Member;
+import java.util.List;
+import lombok.Builder;
+
+public interface AccommodationQueryUseCase {
+
+    Accommodation saveAccommodation(AccommodationSaveRequest accommodationSaveRequest);
+
+    Accommodation getAccommodationById(long id);
+
+    AccommodationOwnership saveOwnership(Member member, Accommodation accommodation);
+
+    List<AccommodationOwnership> getOwnershipByMember(Member member);
+
+    Category getCategoryByName(String name);
+
+    List<AccommodationImage> saveAllImages(List<AccommodationImage> images);
+
+    @Builder
+    record AccommodationSaveRequest(
+        String name,
+        Address address,
+        String description,
+        Category category,
+        String thumbnail,
+        AccommodationOption option
+    ) {
+
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationControllerDocsTest.java
@@ -368,7 +368,7 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
             .build();
 
         given(securityUtil.getCurrentMemberId()).willReturn(1L);
-        given(accommodationCommandService.getAccommodationNames(any(Long.TYPE)))
+        given(accommodationCommandService.getAccommodationOwnership(any(Long.TYPE)))
             .willReturn(accommodationOwnershipResponse);
 
         // when then
@@ -386,6 +386,6 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
                 )
             ));
 
-        verify(accommodationCommandService, times(1)).getAccommodationNames(any(Long.TYPE));
+        verify(accommodationCommandService, times(1)).getAccommodationOwnership(any(Long.TYPE));
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationControllerDocsTest.java
@@ -352,7 +352,7 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
 
     @Test
     @DisplayName("보유 숙소 목록을 조회할 수 있다.")
-    void getAccommodationNames() throws Exception {
+    void getAccommodationOwnership() throws Exception {
         // given
         AccommodationNameResponse accommodationNameResponse1 = AccommodationNameResponse.builder()
             .id(1L)

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
@@ -209,8 +209,8 @@ public class AccommodationControllerTest {
     }
 
     @Nested
-    @DisplayName("getAccommodationNames()은")
-    class Context_getAccommodationNames {
+    @DisplayName("getAccommodationOwnership()은")
+    class Context_getAccommodationOwnership {
 
         @Test
         @DisplayName("보유 숙소 목록을 조회할 수 있다.")

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,8 +16,10 @@ import com.backoffice.upjuyanolja.domain.accommodation.dto.request.Accommodation
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationImageResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationNameResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOptionResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.service.AccommodationService;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.AccommodationCommandService;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomOptionRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomRegisterRequest;
@@ -54,7 +57,7 @@ public class AccommodationControllerTest {
     protected ObjectMapper objectMapper;
 
     @MockBean
-    private AccommodationService accommodationService;
+    private AccommodationCommandService accommodationCommandService;
 
     @MockBean
     private SecurityUtil securityUtil;
@@ -152,8 +155,9 @@ public class AccommodationControllerTest {
                 .build();
 
             given(securityUtil.getCurrentMemberId()).willReturn(1L);
-            given(accommodationService.createAccommodation(any(Long.TYPE),
-                any(AccommodationRegisterRequest.class))).willReturn(accommodationInfoResponse);
+            given(accommodationCommandService
+                .createAccommodation(any(Long.TYPE), any(AccommodationRegisterRequest.class)))
+                .willReturn(accommodationInfoResponse);
 
             // when then
             mockMvc.perform(post("/api/accommodations")
@@ -199,8 +203,43 @@ public class AccommodationControllerTest {
                 .andExpect(jsonPath("$.data.rooms[0].option.internet").isBoolean())
                 .andDo(print());
 
-            verify(accommodationService, times(1)).createAccommodation(any(Long.TYPE),
-                any(AccommodationRegisterRequest.class));
+            verify(accommodationCommandService, times(1))
+                .createAccommodation(any(Long.TYPE), any(AccommodationRegisterRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getAccommodationNames()은")
+    class Context_getAccommodationNames {
+
+        @Test
+        @DisplayName("보유 숙소 목록을 조회할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            AccommodationNameResponse accommodationNameResponse = AccommodationNameResponse.builder()
+                .id(1L)
+                .name("그랜드 하얏트 제주")
+                .build();
+            AccommodationOwnershipResponse accommodationOwnershipResponse = AccommodationOwnershipResponse
+                .builder()
+                .accommodations(List.of(accommodationNameResponse))
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(accommodationCommandService.getAccommodationNames(any(Long.TYPE)))
+                .willReturn(accommodationOwnershipResponse);
+
+            // when then
+            mockMvc.perform(get("/api/accommodations/backoffice"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.accommodations").isArray())
+                .andExpect(jsonPath("$.data.accommodations[0].id").isNumber())
+                .andExpect(jsonPath("$.data.accommodations[0].name").isString())
+                .andDo(print());
+
+            verify(accommodationCommandService, times(1)).getAccommodationNames(any(Long.TYPE));
         }
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/AccommodationControllerTest.java
@@ -226,7 +226,7 @@ public class AccommodationControllerTest {
                 .build();
 
             given(securityUtil.getCurrentMemberId()).willReturn(1L);
-            given(accommodationCommandService.getAccommodationNames(any(Long.TYPE)))
+            given(accommodationCommandService.getAccommodationOwnership(any(Long.TYPE)))
                 .willReturn(accommodationOwnershipResponse);
 
             // when then
@@ -239,7 +239,7 @@ public class AccommodationControllerTest {
                 .andExpect(jsonPath("$.data.accommodations[0].name").isString())
                 .andDo(print());
 
-            verify(accommodationCommandService, times(1)).getAccommodationNames(any(Long.TYPE));
+            verify(accommodationCommandService, times(1)).getAccommodationOwnership(any(Long.TYPE));
         }
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/repository/AccommodationOwnershipRepositoryTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/repository/AccommodationOwnershipRepositoryTest.java
@@ -1,0 +1,198 @@
+package com.backoffice.upjuyanolja.domain.accommodation.unit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwnership;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Address;
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Category;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationOwnershipRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationRepository;
+import com.backoffice.upjuyanolja.domain.accommodation.repository.CategoryRepository;
+import com.backoffice.upjuyanolja.domain.member.entity.Authority;
+import com.backoffice.upjuyanolja.domain.member.entity.Member;
+import com.backoffice.upjuyanolja.domain.member.repository.MemberRepository;
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import com.backoffice.upjuyanolja.domain.room.entity.RoomOption;
+import com.backoffice.upjuyanolja.domain.room.entity.RoomPrice;
+import com.backoffice.upjuyanolja.domain.room.entity.RoomStatus;
+import com.backoffice.upjuyanolja.domain.room.repository.RoomRepository;
+import com.backoffice.upjuyanolja.global.config.QueryDslConfig;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@Import(QueryDslConfig.class)
+public class AccommodationOwnershipRepositoryTest {
+
+    @Autowired
+    private AccommodationOwnershipRepository accommodationOwnershipRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private AccommodationRepository accommodationRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    public void reset() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        roomRepository.deleteAll();
+        categoryRepository.deleteAll();
+        accommodationRepository.deleteAll();
+        accommodationOwnershipRepository.deleteAll();
+        memberRepository.deleteAll();
+        entityManager.createNativeQuery("TRUNCATE TABLE room").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE category").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE accommodation").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE accommodation_ownership").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE member").executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE room ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE category ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE accommodation ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery(
+                "ALTER TABLE accommodation_ownership ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager
+            .createNativeQuery("ALTER TABLE member ALTER COLUMN `id` RESTART WITH 1")
+            .executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private AccommodationOwnership saveAccommodationOwnership(Accommodation accommodation,
+        Member member) {
+        return accommodationOwnershipRepository.save(AccommodationOwnership.builder()
+            .accommodation(accommodation)
+            .member(member)
+            .build()
+        );
+    }
+
+    private Category saveCategory() {
+        return categoryRepository.save(Category.builder()
+            .id(5L)
+            .name("TOURIST_HOTEL")
+            .build()
+        );
+    }
+
+    private Accommodation saveAccommodation() {
+        return accommodationRepository.save(Accommodation.builder()
+            .name("그랜드 하얏트 제주")
+            .address(Address.builder()
+                .address("제주특별자치도 제주시 노형동 925")
+                .detailAddress("")
+                .build())
+            .category(saveCategory())
+            .description(
+                "63빌딩의 1.8배 규모인 연면적 30만 3737m2, 높이 169m(38층)를 자랑하는 제주 최대 높이, 최대 규모의 랜드마크이다. 제주 고도제한선(55m)보다 높이 위치한 1,600 올스위트 객실, 월드클래스 셰프들이 포진해 있는 14개의 글로벌 레스토랑 & 바, 인피니티 풀을 포함한 8층 야외풀데크, 38층 스카이데크를 비롯해 HAN컬렉션 K패션 쇼핑몰, 2개의 프리미엄 스파, 8개의 연회장 등 라스베이거스, 싱가포르, 마카오에서나 볼 수 있는 세계적인 수준의 복합리조트이다. 제주국제공항에서 차량으로 10분거리(5km)이며 제주의 강남이라고 불리는 신제주 관광 중심지에 위치하고 있다.")
+            .thumbnail("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+            .option(AccommodationOption.builder()
+                .cooking(false)
+                .parking(true)
+                .pickup(false)
+                .barbecue(false)
+                .fitness(true)
+                .karaoke(false)
+                .sauna(false)
+                .sports(true)
+                .seminar(true)
+                .build())
+            .images(new ArrayList<>())
+            .rooms(new ArrayList<>())
+            .build());
+    }
+
+    private Member saveMember() {
+        return memberRepository.save(Member.builder()
+            .email("test@mail.com")
+            .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+            .name("test")
+            .phone("010-1234-1234")
+            .imageUrl(
+                "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+            .authority(Authority.ROLE_ADMIN)
+            .build());
+    }
+
+    private Room saveRoom(Accommodation accommodation) {
+        return roomRepository.save(Room.builder()
+            .accommodation(accommodation)
+            .name("65m² 킹룸")
+            .standard(2)
+            .capacity(3)
+            .checkInTime(LocalTime.of(15, 0, 0))
+            .checkOutTime(LocalTime.of(11, 0, 0))
+            .price(RoomPrice.builder()
+                .offWeekDaysMinFee(100000)
+                .offWeekendMinFee(100000)
+                .peakWeekDaysMinFee(100000)
+                .peakWeekendMinFee(100000)
+                .build())
+            .amount(858)
+            .status(RoomStatus.SELLING)
+            .option(RoomOption.builder()
+                .airCondition(true)
+                .tv(true)
+                .internet(true)
+                .build())
+            .images(new ArrayList<>())
+            .build());
+    }
+
+    @Nested
+    @DisplayName("findAllByMember()는")
+    class Context_findAllByMember {
+
+        @Test
+        @DisplayName("")
+        void _willSuccess() {
+            // given
+            Accommodation accommodation = saveAccommodation();
+            saveRoom(accommodation);
+            Member member = saveMember();
+            saveAccommodationOwnership(accommodation, member);
+
+            // when
+            List<AccommodationOwnership> result = accommodationOwnershipRepository
+                .findAllByMember(member);
+
+            // then
+            assertThat(result).isNotEmpty();
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getAccommodation().getId()).isEqualTo(accommodation.getId());
+            assertThat(result.get(0).getMember().getId()).isEqualTo(member.getId());
+        }
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
@@ -369,7 +369,7 @@ public class AccommodationCommandServiceTest {
 
             // when
             AccommodationOwnershipResponse result = accommodationCommandService
-                .getAccommodationNames(1L);
+                .getAccommodationOwnership(1L);
 
             // then
             assertThat(result).isNotNull();

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
@@ -8,6 +8,7 @@ import com.backoffice.upjuyanolja.domain.accommodation.dto.request.Accommodation
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationOptionRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationNameResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationImage;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
@@ -237,7 +238,8 @@ public class AccommodationServiceTest {
                 .build();
 
             given(memberGetService.getMemberById(any(Long.TYPE))).willReturn(member);
-            given(categoryRepository.findCategoryByName(any(String.class))).willReturn(Optional.of(category));
+            given(categoryRepository.findCategoryByName(any(String.class))).willReturn(
+                Optional.of(category));
             given(accommodationRepository.save(any(Accommodation.class))).willReturn(accommodation);
             given(accommodationImageRepository.saveAll(any(Iterable.class))).willReturn(
                 List.of(accommodationImage));
@@ -262,6 +264,127 @@ public class AccommodationServiceTest {
             assertThat(result.images()).isNotEmpty();
             assertThat(result.option()).isNotNull();
             assertThat(result.rooms()).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getAccommodationNames()은")
+    class Context_getAccommodationNames {
+
+        @Test
+        @DisplayName("보유 숙소 목록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .name("test")
+                .phone("010-1234-1234")
+                .imageUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_ADMIN)
+                .build();
+            Category category = Category.builder()
+                .id(5L)
+                .name("TOURIST_HOTEL")
+                .build();
+            Accommodation accommodation = Accommodation.builder()
+                .id(1L)
+                .name("그랜드 하얏트 제주")
+                .address(Address.builder()
+                    .address("제주특별자치도 제주시 노형동 925")
+                    .detailAddress("")
+                    .build())
+                .category(category)
+                .description(
+                    "63빌딩의 1.8배 규모인 연면적 30만 3737m2, 높이 169m(38층)를 자랑하는 제주 최대 높이, 최대 규모의 랜드마크이다. 제주 고도제한선(55m)보다 높이 위치한 1,600 올스위트 객실, 월드클래스 셰프들이 포진해 있는 14개의 글로벌 레스토랑 & 바, 인피니티 풀을 포함한 8층 야외풀데크, 38층 스카이데크를 비롯해 HAN컬렉션 K패션 쇼핑몰, 2개의 프리미엄 스파, 8개의 연회장 등 라스베이거스, 싱가포르, 마카오에서나 볼 수 있는 세계적인 수준의 복합리조트이다. 제주국제공항에서 차량으로 10분거리(5km)이며 제주의 강남이라고 불리는 신제주 관광 중심지에 위치하고 있다.")
+                .thumbnail("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+                .option(AccommodationOption.builder()
+                    .cooking(false)
+                    .parking(true)
+                    .pickup(false)
+                    .barbecue(false)
+                    .fitness(true)
+                    .karaoke(false)
+                    .sauna(false)
+                    .sports(true)
+                    .seminar(true)
+                    .build())
+                .images(new ArrayList<>())
+                .rooms(new ArrayList<>())
+                .build();
+            AccommodationImage accommodationImage = AccommodationImage.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .url("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+                .build();
+            Room room = Room.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .name("65m² 킹룸")
+                .standard(2)
+                .capacity(3)
+                .checkInTime(LocalTime.of(15, 0, 0))
+                .checkOutTime(LocalTime.of(11, 0, 0))
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(100000)
+                    .offWeekendMinFee(100000)
+                    .peakWeekDaysMinFee(100000)
+                    .peakWeekendMinFee(100000)
+                    .build())
+                .amount(858)
+                .status(RoomStatus.SELLING)
+                .option(RoomOption.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(new ArrayList<>())
+                .build();
+            Accommodation savedAccommodation = Accommodation.builder()
+                .id(1L)
+                .name("그랜드 하얏트 제주")
+                .address(Address.builder()
+                    .address("제주특별자치도 제주시 노형동 925")
+                    .detailAddress("")
+                    .build())
+                .category(category)
+                .description(
+                    "63빌딩의 1.8배 규모인 연면적 30만 3737m2, 높이 169m(38층)를 자랑하는 제주 최대 높이, 최대 규모의 랜드마크이다. 제주 고도제한선(55m)보다 높이 위치한 1,600 올스위트 객실, 월드클래스 셰프들이 포진해 있는 14개의 글로벌 레스토랑 & 바, 인피니티 풀을 포함한 8층 야외풀데크, 38층 스카이데크를 비롯해 HAN컬렉션 K패션 쇼핑몰, 2개의 프리미엄 스파, 8개의 연회장 등 라스베이거스, 싱가포르, 마카오에서나 볼 수 있는 세계적인 수준의 복합리조트이다. 제주국제공항에서 차량으로 10분거리(5km)이며 제주의 강남이라고 불리는 신제주 관광 중심지에 위치하고 있다.")
+                .thumbnail("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+                .option(AccommodationOption.builder()
+                    .cooking(false)
+                    .parking(true)
+                    .pickup(false)
+                    .barbecue(false)
+                    .fitness(true)
+                    .karaoke(false)
+                    .sauna(false)
+                    .sports(true)
+                    .seminar(true)
+                    .build())
+                .images(List.of(accommodationImage))
+                .rooms(List.of(room))
+                .build();
+            AccommodationOwnership accommodationOwnership = AccommodationOwnership.builder()
+                .id(1L)
+                .accommodation(savedAccommodation)
+                .member(member)
+                .build();
+
+            given(memberGetService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(accommodationOwnershipRepository.findAllByMember(any(Member.class))).willReturn(
+                List.of(accommodationOwnership));
+
+            // when
+            List<AccommodationNameResponse> result = accommodationService.getAccommodationNames(1L);
+
+            // then
+            assertThat(result).isNotEmpty();
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).id()).isEqualTo(1L);
+            assertThat(result.get(0).name()).isEqualTo("그랜드 하얏트 제주");
         }
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
@@ -258,8 +258,8 @@ public class AccommodationCommandServiceTest {
     }
 
     @Nested
-    @DisplayName("getAccommodationNames()은")
-    class Context_getAccommodationNames {
+    @DisplayName("getAccommodationOwnership()은")
+    class Context_getAccommodationOwnership {
 
         @Test
         @DisplayName("보유 숙소 목록을 조회할 수 있다.")


### PR DESCRIPTION
### 💡Motivation
- 업주 회원이 보유한 숙소 목록을 조회할 수 있도록 기능을 구현해야 합니다. 
- 숙소와 객실 간의 순환 참조를 피하고 서비스 레이어 간 결합도를 낮추기 위해 서비스를 나눴습니다. 

### 📌Changes
- 숙소 서비스 분리
- 보유 숙소 목록 조회 기능 구현
- 보유 숙소 목록 조회 기능 테스트 작성
- 보유 숙소 목록 조회 API Docs 테스트 및 adoc 작성

### 🫱🏻‍🫲🏻To Reviewers
- 코드 리뷰 및 승인 부탁 드립니다!! 😊

closes #66 