### PR TITLE
fix: submodule hash update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,15 +93,15 @@ tasks.named('asciidoctor') {
 }
 
 task copyPrivate(type: Copy) {
-    from './submodule-data'
+    from './submodule-data/main'
     include "application.yaml", "application-local.yaml", "application-prod.yaml"
     into 'src/main/resources'
 
-    from './submodule-data'
+    from './submodule-data/test'
     include "application-test.yaml"
     into 'src/test/resources'
 
-    from './submodule-data'
+    from './submodule-data/ssl'
     include "keystore.p12"
     into 'src/main/resources/ssl'
 }


### PR DESCRIPTION
### 💡Motivation
- 배포 서버에서 서브 모듈 복사가 제대로 동작하지 않음

### 📌Changes
- 서브 모듈 파일 구조 수정
- 서브 모듈 구조 수정에 따른 gradle 수정 
- 서브 모듈 최신 hash -> 프로젝트 repository 에 commit

### 🫱🏻‍🫲🏻To Reviewers
git submodule 은  branch의 hash를 작성하는 방식이다.
git submodule update --remote 명령을 실행하면 Git이 알아서 서브모듈 프로젝트를 Fetch 하고 업데이트한다.
하지만, 본 프로젝트에 commit을 통해 hash를 업데이트 하면 git submodule update --remote을 따로 수행하지 않아도 된다. 

이전 hash에 머물러 있는 상태
![image](https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/65496092/aa523b49-31a6-49d4-a340-2695296dbf1a)

현재 서브 모듈 hash
![image](https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/65496092/a33f6409-0af2-4060-a20b-fe21aec928ac)

참고문서 
[7.11 Git 도구 - 서브모듈](https://git-scm.com/book/ko/v2/Git-%EB%8F%84%EA%B5%AC-%EC%84%9C%EB%B8%8C%EB%AA%A8%EB%93%88)
[Spring Boot에서 git submodule로 민감 정보(yml) 관리](https://choieungi.github.io/posts/git-submodule/)