### PR TITLE
fix: submodule copy 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,17 +93,23 @@ tasks.named('asciidoctor') {
 }
 
 task copyPrivate(type: Copy) {
-    from './submodule-data/main'
-    include "application.yaml", "application-local.yaml", "application-prod.yaml"
-    into 'src/main/resources'
+    copy {
+        from './submodule-data/main'
+        include "application.yaml", "application-local.yaml", "application-prod.yaml"
+        into 'src/main/resources'
+    }
 
-    from './submodule-data/test'
-    include "application-test.yaml"
-    into 'src/test/resources'
+    copy {
+        from './submodule-data/test'
+        include "application.yaml"
+        into 'src/test/resources'
+    }
 
-    from './submodule-data/ssl'
-    include "keystore.p12"
-    into 'src/main/resources/ssl'
+    copy {
+        from './submodule-data/ssl'
+        include "keystore.p12"
+        into 'src/main/resources/ssl'
+    }
 }
 
 bootJar {


### PR DESCRIPTION
### 💡Motivation
``` java
task copyPrivate(type: Copy) {
    from './submodule-data/main'
    include "application.yaml", "application-local.yaml", "application-prod.yaml"
    into 'src/main/resources'

    from './submodule-data/test'
    include "application-test.yaml"
    into 'src/test/resources'

    from './submodule-data/ssl'
    include "keystore.p12"
    into 'src/main/resources/ssl'
}
```
copy 명령이 분리가 안되어 있어 
모든 파일이 src/main/resources/ssl에만 copy 되는 현상 발생

상위의 모든 from-include 가 합쳐져서  into 'src/main/resources/ssl' 가 적용되는것 같음 

![image](https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/65496092/47587c10-752c-4d00-b63a-4bf0f1572160)

### 📌Changes
- copy{} 블록으로 분리 

### 🫱🏻‍🫲🏻To Reviewers
closes #91 