### PR TITLE
feat: 객실 목록 조회, 객실 상세 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/room/room-api.adoc
+++ b/src/docs/asciidoc/room/room-api.adoc
@@ -25,6 +25,37 @@ include::{snippets}/room-controller-docs-test/register-room/request-fields.adoc[
 include::{snippets}/room-controller-docs-test/register-room/http-response.adoc[]
 include::{snippets}/room-controller-docs-test/register-room/response-fields.adoc[]
 
+[[Get-Rooms]]
+== 객실 목록 조회
+
+객실 목록 조회 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/room-controller-docs-test/get-rooms/http-request.adoc[]
+include::{snippets}/room-controller-docs-test/get-rooms/path-parameters.adoc[]
+include::{snippets}/room-controller-docs-test/get-rooms/query-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/room-controller-docs-test/get-rooms/http-response.adoc[]
+include::{snippets}/room-controller-docs-test/get-rooms/response-fields.adoc[]
+
+[[Get-Room]]
+== 객실 상세 조회
+
+객실 상세 조회 API 입니다.
+
+=== HttpRequest
+
+include::{snippets}/room-controller-docs-test/get-room/http-request.adoc[]
+include::{snippets}/room-controller-docs-test/get-room/path-parameters.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/room-controller-docs-test/get-room/http-response.adoc[]
+include::{snippets}/room-controller-docs-test/get-room/response-fields.adoc[]
+
 [[Modify-Room]]
 == 객실 수정
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
@@ -1,8 +1,10 @@
 package com.backoffice.upjuyanolja.domain.room.controller;
 
+import com.backoffice.upjuyanolja.domain.room.dto.request.RoomPageRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomRegisterRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import com.backoffice.upjuyanolja.global.common.response.ApiResponse;
 import com.backoffice.upjuyanolja.global.common.response.ApiResponse.SuccessResponse;
@@ -11,11 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -42,6 +46,42 @@ public class RoomController {
                     accommodationId,
                     roomRegisterRequest)
                 )
+                .build()
+        );
+    }
+
+    @GetMapping("/list/{accommodationId}")
+    public ResponseEntity<SuccessResponse<RoomPageResponse>> getRooms(
+        @PathVariable long accommodationId,
+        @RequestParam(defaultValue = "0") int pageNum,
+        @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        log.info("GET /api/rooms/list/{}", accommodationId);
+
+        return ApiResponse.success(HttpStatus.OK,
+            SuccessResponse.<RoomPageResponse>builder()
+                .message("성공적으로 객실 목록을 조회했습니다.")
+                .data(roomCommandUseCase.getRooms(
+                        securityUtil.getCurrentMemberId(),
+                        accommodationId,
+                        RoomPageRequest.builder()
+                            .pageNum(pageNum)
+                            .pageSize(pageSize)
+                            .build().of()
+                    )
+                )
+                .build()
+        );
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<SuccessResponse<RoomInfoResponse>> getRoom(@PathVariable long roomId) {
+        log.info("GET /api/rooms/{}", roomId);
+
+        return ApiResponse.success(HttpStatus.OK,
+            SuccessResponse.<RoomInfoResponse>builder()
+                .message("성공적으로 객실을 조회했습니다.")
+                .data(roomCommandUseCase.getRoom(securityUtil.getCurrentMemberId(), roomId))
                 .build()
         );
     }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/request/RoomPageRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/request/RoomPageRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.upjuyanolja.domain.room.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record RoomPageRequest(int pageNum, int pageSize) {
+
+    public org.springframework.data.domain.PageRequest of() {
+        return org.springframework.data.domain.PageRequest.of(pageNum, pageSize);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomPageResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomPageResponse.java
@@ -1,0 +1,16 @@
+package com.backoffice.upjuyanolja.domain.room.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RoomPageResponse(
+    int pageNum,
+    int pageSize,
+    int totalPages,
+    long totalElements,
+    boolean isLast,
+    List<RoomInfoResponse> rooms
+) {
+
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepository.java
@@ -1,0 +1,10 @@
+package com.backoffice.upjuyanolja.domain.room.repository;
+
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RoomCustomRepository {
+
+    Page<Room> findAllByAccommodation(long accommodationId, Pageable pageable);
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.backoffice.upjuyanolja.domain.room.repository;
+
+import static com.backoffice.upjuyanolja.domain.accommodation.entity.QAccommodation.accommodation;
+import static com.backoffice.upjuyanolja.domain.room.entity.QRoom.room;
+import static com.backoffice.upjuyanolja.domain.room.entity.QRoomImage.roomImage;
+import static com.backoffice.upjuyanolja.domain.room.entity.QRoomOption.roomOption;
+
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import com.backoffice.upjuyanolja.global.util.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RoomCustomRepositoryImpl implements RoomCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    RoomCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        this.queryFactory = jpaQueryFactory;
+    }
+
+    @Override
+    public Page<Room> findAllByAccommodation(long accommodationId, Pageable pageable) {
+        JPAQuery<Room> query = queryFactory
+            .select(room)
+            .from(room)
+            .leftJoin(room.accommodation, accommodation).fetchJoin()
+            .leftJoin(room.option, roomOption).fetchJoin()
+            .leftJoin(room.images, roomImage).fetchJoin()
+            .where(room.accommodation.id.eq(accommodationId))
+            .offset(pageable.getOffset())
+            .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
+            .limit(pageable.getPageSize());
+        JPAQuery<Room> countQuery = queryFactory
+            .select(room)
+            .leftJoin(room.accommodation, accommodation).fetchJoin()
+            .leftJoin(room.option, roomOption).fetchJoin()
+            .leftJoin(room.images, roomImage).fetchJoin()
+            .where(room.accommodation.id.eq(accommodationId));
+        List<Room> content = query.fetch();
+        return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+    }
+
+    private List<OrderSpecifier<?>> getAllOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new LinkedList<>();
+        orders.add(QueryDslUtil.getSortedColumn(Order.ASC, room, "id"));
+        return orders;
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomRepository.java
@@ -3,7 +3,7 @@ package com.backoffice.upjuyanolja.domain.room.repository;
 import com.backoffice.upjuyanolja.domain.room.entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RoomRepository extends JpaRepository<Room, Long> {
+public interface RoomRepository extends JpaRepository<Room, Long>, RoomCustomRepository {
 
     boolean existsRoomByName(String name);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
@@ -34,6 +34,7 @@ public class RoomQueryService implements RoomQueryUseCase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<Room> findAllByAccommodationId(long accommodationId, Pageable pageable) {
         return roomRepository.findAllByAccommodation(accommodationId, pageable);
     }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
@@ -10,6 +10,8 @@ import com.backoffice.upjuyanolja.domain.room.repository.RoomRepository;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomQueryUseCase;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,11 @@ public class RoomQueryService implements RoomQueryUseCase {
     @Override
     public List<RoomImage> saveRoomImages(List<RoomImage> requests) {
         return roomImageRepository.saveAll(requests);
+    }
+
+    @Override
+    public Page<Room> findAllByAccommodationId(long accommodationId, Pageable pageable) {
+        return roomRepository.findAllByAccommodation(accommodationId, pageable);
     }
 
     @Override

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomCommandUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomCommandUseCase.java
@@ -4,13 +4,19 @@ import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomRegisterRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
 import lombok.Builder;
+import org.springframework.data.domain.Pageable;
 
 public interface RoomCommandUseCase {
 
     RoomInfoResponse registerRoom(long memberId, long accommodationId, RoomRegisterRequest request);
 
     RoomInfoResponse saveRoom(Accommodation accommodation, RoomRegisterRequest request);
+
+    RoomPageResponse getRooms(long memberId, long accommodationId, Pageable pageable);
+
+    RoomInfoResponse getRoom(long memberId, long roomId);
 
     RoomInfoResponse modifyRoom(long memberId, long roomId, RoomUpdateRequest request);
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomQueryUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomQueryUseCase.java
@@ -8,12 +8,16 @@ import com.backoffice.upjuyanolja.domain.room.entity.RoomPrice;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface RoomQueryUseCase {
 
     Room saveRoom(Accommodation accommodation, Room request);
 
     List<RoomImage> saveRoomImages(List<RoomImage> request);
+
+    Page<Room> findAllByAccommodationId(long accommodationId, Pageable pageable);
 
     Room findRoomById(long id);
 

--- a/src/main/java/com/backoffice/upjuyanolja/global/util/QueryDslUtil.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/util/QueryDslUtil.java
@@ -1,0 +1,14 @@
+package com.backoffice.upjuyanolja.global.util;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class QueryDslUtil {
+
+    public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
+        Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
+        return new OrderSpecifier(order, fieldPath);
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -11,6 +12,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageAddRequest;
@@ -22,6 +24,7 @@ import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomImageResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomOptionResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
 import com.backoffice.upjuyanolja.global.util.RestDocsSupport;
@@ -29,6 +32,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -198,6 +202,189 @@ public class RoomControllerDocsTest extends RestDocsSupport {
 
         verify(roomCommandUseCase, times(1))
             .registerRoom(any(Long.TYPE), any(Long.TYPE), any(RoomRegisterRequest.class));
+    }
+
+    @Test
+    @DisplayName("객실 목록을 조회할 수 있다.")
+    void getRooms() throws Exception {
+        // given
+        RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+            .id(1L)
+            .name("65m² 킹룸")
+            .defaultCapacity(2)
+            .maxCapacity(3)
+            .checkInTime("15:00")
+            .checkOutTime("11:00")
+            .price(100000)
+            .amount(858)
+            .status("SELLING")
+            .option(RoomOptionResponse.builder()
+                .airCondition(true)
+                .tv(true)
+                .internet(true)
+                .build())
+            .images(List.of(RoomImageResponse.builder()
+                .id(1L)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                .build()))
+            .build();
+
+        RoomPageResponse roomPageResponse = RoomPageResponse.builder()
+            .pageNum(0)
+            .pageSize(10)
+            .totalPages(1)
+            .totalElements(1)
+            .isLast(true)
+            .rooms(List.of(roomInfoResponse))
+            .build();
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(roomCommandUseCase
+            .getRooms(any(Long.TYPE), any(Long.TYPE), any(Pageable.class)))
+            .willReturn(roomPageResponse);
+
+        // when then
+        mockMvc.perform(get("/api/rooms/list/{accommodationId}", 1L)
+                .queryParam("pageNum", "0")
+                .queryParam("pageSize", "10"))
+            .andDo(restDoc.document(
+                queryParameters(
+                    parameterWithName("pageNum").description("조회할 페이지 번호 (기본값: 0)"),
+                    parameterWithName("pageSize").description("한 페이지 크기 (기본값: 10)")
+                ),
+                pathParameters(
+                    parameterWithName("accommodationId").description("객실 목록을 조회할 숙소 식별자")
+                ),
+                responseFields(successResponseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터"),
+                    fieldWithPath("data.pageNum").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지 번호"),
+                    fieldWithPath("data.pageSize").type(JsonFieldType.NUMBER)
+                        .description("한 페이지 크기"),
+                    fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER)
+                        .description("전체 페이지 개수"),
+                    fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
+                        .description("전체 객실 개수"),
+                    fieldWithPath("data.isLast").type(JsonFieldType.BOOLEAN)
+                        .description("마지막 페이지 여부"),
+                    fieldWithPath("data.rooms").type(JsonFieldType.ARRAY)
+                        .description("객실 목록"),
+                    fieldWithPath("data.rooms[].id").type(JsonFieldType.NUMBER)
+                        .description("객실 식별자"),
+                    fieldWithPath("data.rooms[].name").type(JsonFieldType.STRING)
+                        .description("객실 이름"),
+                    fieldWithPath("data.rooms[].defaultCapacity").type(JsonFieldType.NUMBER)
+                        .description("객실 기본 인원"),
+                    fieldWithPath("data.rooms[].maxCapacity").type(JsonFieldType.NUMBER)
+                        .description("객실 최대 인원"),
+                    fieldWithPath("data.rooms[].checkInTime").type(JsonFieldType.STRING)
+                        .description("객실 체크인 시간"),
+                    fieldWithPath("data.rooms[].checkOutTime").type(JsonFieldType.STRING)
+                        .description("객실 체크아웃 시간"),
+                    fieldWithPath("data.rooms[].price").type(JsonFieldType.NUMBER)
+                        .description("객실 가격"),
+                    fieldWithPath("data.rooms[].amount").type(JsonFieldType.NUMBER)
+                        .description("객실 개수"),
+                    fieldWithPath("data.rooms[].status").type(JsonFieldType.STRING)
+                        .description("객실 상태"),
+                    fieldWithPath("data.rooms[].images").type(JsonFieldType.ARRAY)
+                        .description("객실 이미지 배열"),
+                    fieldWithPath("data.rooms[].images[].id").type(JsonFieldType.NUMBER)
+                        .description("객실 이미지 식별자"),
+                    fieldWithPath("data.rooms[].images[].url").type(JsonFieldType.STRING)
+                        .description("객실 이미지 URL"),
+                    fieldWithPath("data.rooms[].option").type(JsonFieldType.OBJECT)
+                        .description("객실 옵션"),
+                    fieldWithPath("data.rooms[].option.airCondition").type(
+                            JsonFieldType.BOOLEAN)
+                        .description("에어컨 여부"),
+                    fieldWithPath("data.rooms[].option.tv").type(JsonFieldType.BOOLEAN)
+                        .description("TV 여부"),
+                    fieldWithPath("data.rooms[].option.internet").type(JsonFieldType.BOOLEAN)
+                        .description("인터넷 여부")
+                )
+            ));
+
+        verify(roomCommandUseCase, times(1))
+            .getRooms(any(Long.TYPE), any(Long.TYPE), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("객실을 조회할 수 있다.")
+    void getRoom() throws Exception {
+        // given
+        RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+            .id(1L)
+            .name("65m² 킹룸")
+            .defaultCapacity(2)
+            .maxCapacity(3)
+            .checkInTime("15:00")
+            .checkOutTime("11:00")
+            .price(100000)
+            .amount(858)
+            .status("SELLING")
+            .option(RoomOptionResponse.builder()
+                .airCondition(true)
+                .tv(true)
+                .internet(true)
+                .build())
+            .images(List.of(RoomImageResponse.builder()
+                .id(1L)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                .build()))
+            .build();
+
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(roomCommandUseCase.getRoom(any(Long.TYPE), any(Long.TYPE)))
+            .willReturn(roomInfoResponse);
+
+        // when then
+        mockMvc.perform(get("/api/rooms/{roomId}", 1L))
+            .andDo(restDoc.document(
+                pathParameters(
+                    parameterWithName("roomId").description("조회할 객실 식별자")
+                ),
+                responseFields(successResponseCommon()).and(
+                    fieldWithPath("data").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터"),
+                    fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                        .description("객실 식별자"),
+                    fieldWithPath("data.name").type(JsonFieldType.STRING)
+                        .description("객실 이름"),
+                    fieldWithPath("data.defaultCapacity").type(JsonFieldType.NUMBER)
+                        .description("객실 기본 인원"),
+                    fieldWithPath("data.maxCapacity").type(JsonFieldType.NUMBER)
+                        .description("객실 최대 인원"),
+                    fieldWithPath("data.checkInTime").type(JsonFieldType.STRING)
+                        .description("객실 체크인 시간"),
+                    fieldWithPath("data.checkOutTime").type(JsonFieldType.STRING)
+                        .description("객실 체크아웃 시간"),
+                    fieldWithPath("data.price").type(JsonFieldType.NUMBER)
+                        .description("객실 가격"),
+                    fieldWithPath("data.amount").type(JsonFieldType.NUMBER)
+                        .description("객실 개수"),
+                    fieldWithPath("data.status").type(JsonFieldType.STRING)
+                        .description("객실 상태"),
+                    fieldWithPath("data.images").type(JsonFieldType.ARRAY)
+                        .description("객실 이미지 배열"),
+                    fieldWithPath("data.images[].id").type(JsonFieldType.NUMBER)
+                        .description("객실 이미지 식별자"),
+                    fieldWithPath("data.images[].url").type(JsonFieldType.STRING)
+                        .description("객실 이미지 URL"),
+                    fieldWithPath("data.option").type(JsonFieldType.OBJECT)
+                        .description("객실 옵션"),
+                    fieldWithPath("data.option.airCondition").type(
+                            JsonFieldType.BOOLEAN)
+                        .description("에어컨 여부"),
+                    fieldWithPath("data.option.tv").type(JsonFieldType.BOOLEAN)
+                        .description("TV 여부"),
+                    fieldWithPath("data.option.internet").type(JsonFieldType.BOOLEAN)
+                        .description("인터넷 여부")
+                )
+            ));
+
+        verify(roomCommandUseCase, times(1)).getRoom(any(Long.TYPE), any(Long.TYPE));
     }
 
     @Test

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -20,6 +21,7 @@ import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomImageResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomOptionResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import com.backoffice.upjuyanolja.global.security.AuthenticationConfig;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
@@ -35,6 +37,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -136,6 +139,145 @@ public class RoomControllerTest {
 
             verify(roomCommandUseCase, times(1))
                 .registerRoom(any(Long.TYPE), any(Long.TYPE), any(RoomRegisterRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRooms()은")
+    class Context_getRooms {
+
+        @Test
+        @DisplayName("객실 목록을 조회할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+                .id(1L)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime("15:00")
+                .checkOutTime("11:00")
+                .price(100000)
+                .amount(858)
+                .status("SELLING")
+                .option(RoomOptionResponse.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(List.of(RoomImageResponse.builder()
+                    .id(1L)
+                    .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                    .build()))
+                .build();
+
+            RoomPageResponse roomPageResponse = RoomPageResponse.builder()
+                .pageNum(0)
+                .pageSize(10)
+                .totalPages(1)
+                .totalElements(1)
+                .isLast(true)
+                .rooms(List.of(roomInfoResponse))
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(roomCommandUseCase
+                .getRooms(any(Long.TYPE), any(Long.TYPE), any(Pageable.class)))
+                .willReturn(roomPageResponse);
+
+            // when then
+            mockMvc.perform(get("/api/rooms/list/{accommodationId}", 1L)
+                    .queryParam("pageNum", "0")
+                    .queryParam("pageSize", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.pageNum").isNumber())
+                .andExpect(jsonPath("$.data.pageSize").isNumber())
+                .andExpect(jsonPath("$.data.totalPages").isNumber())
+                .andExpect(jsonPath("$.data.totalElements").isNumber())
+                .andExpect(jsonPath("$.data.isLast").isBoolean())
+                .andExpect(jsonPath("$.data.rooms").isArray())
+                .andExpect(jsonPath("$.data.rooms[0].id").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].name").isString())
+                .andExpect(jsonPath("$.data.rooms[0].defaultCapacity").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].maxCapacity").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].checkInTime").isString())
+                .andExpect(jsonPath("$.data.rooms[0].checkOutTime").isString())
+                .andExpect(jsonPath("$.data.rooms[0].price").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].amount").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].status").isString())
+                .andExpect(jsonPath("$.data.rooms[0].images").isArray())
+                .andExpect(jsonPath("$.data.rooms[0].images[0].id").isNumber())
+                .andExpect(jsonPath("$.data.rooms[0].images[0].url").isString())
+                .andExpect(jsonPath("$.data.rooms[0].option").isMap())
+                .andExpect(jsonPath("$.data.rooms[0].option.airCondition").isBoolean())
+                .andExpect(jsonPath("$.data.rooms[0].option.tv").isBoolean())
+                .andExpect(jsonPath("$.data.rooms[0].option.internet").isBoolean())
+                .andDo(print());
+
+            verify(roomCommandUseCase, times(1))
+                .getRooms(any(Long.TYPE), any(Long.TYPE), any(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRoom()은")
+    class Context_getRoom {
+
+        @Test
+        @DisplayName("객실을 조회할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+                .id(1L)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime("15:00")
+                .checkOutTime("11:00")
+                .price(100000)
+                .amount(858)
+                .status("SELLING")
+                .option(RoomOptionResponse.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(List.of(RoomImageResponse.builder()
+                    .id(1L)
+                    .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                    .build()))
+                .build();
+
+            given(securityUtil.getCurrentMemberId()).willReturn(1L);
+            given(roomCommandUseCase.getRoom(any(Long.TYPE), any(Long.TYPE)))
+                .willReturn(roomInfoResponse);
+
+            // when then
+            mockMvc.perform(get("/api/rooms/{accommodationId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.data").isMap())
+                .andExpect(jsonPath("$.data.id").isNumber())
+                .andExpect(jsonPath("$.data.name").isString())
+                .andExpect(jsonPath("$.data.defaultCapacity").isNumber())
+                .andExpect(jsonPath("$.data.maxCapacity").isNumber())
+                .andExpect(jsonPath("$.data.checkInTime").isString())
+                .andExpect(jsonPath("$.data.checkOutTime").isString())
+                .andExpect(jsonPath("$.data.price").isNumber())
+                .andExpect(jsonPath("$.data.amount").isNumber())
+                .andExpect(jsonPath("$.data.status").isString())
+                .andExpect(jsonPath("$.data.images").isArray())
+                .andExpect(jsonPath("$.data.images[0].id").isNumber())
+                .andExpect(jsonPath("$.data.images[0].url").isString())
+                .andExpect(jsonPath("$.data.option").isMap())
+                .andExpect(jsonPath("$.data.option.airCondition").isBoolean())
+                .andExpect(jsonPath("$.data.option.tv").isBoolean())
+                .andExpect(jsonPath("$.data.option.internet").isBoolean())
+                .andDo(print());
+
+            verify(roomCommandUseCase, times(1)).getRoom(any(Long.TYPE), any(Long.TYPE));
         }
     }
 

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/service/RoomCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/service/RoomCommandServiceTest.java
@@ -22,9 +22,11 @@ import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageAddRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageDeleteRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomOptionRequest;
+import com.backoffice.upjuyanolja.domain.room.dto.request.RoomPageRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomRegisterRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
 import com.backoffice.upjuyanolja.domain.room.entity.Room;
 import com.backoffice.upjuyanolja.domain.room.entity.RoomImage;
 import com.backoffice.upjuyanolja.domain.room.entity.RoomOption;
@@ -44,6 +46,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -526,6 +530,337 @@ public class RoomCommandServiceTest {
             assertEquals(exception.getMessage(), "중복된 객실 이름입니다.");
 
             verify(roomQueryUseCase, times(1)).existsRoomByName(any(String.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRooms()은")
+    class Context_getRooms {
+
+        @Test
+        @DisplayName("객실 목록을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            RoomPageRequest roomPageRequest = RoomPageRequest.builder()
+                .pageNum(0)
+                .pageSize(10)
+                .build();
+
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .name("test")
+                .phone("010-1234-1234")
+                .imageUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            Category category = Category.builder()
+                .id(5L)
+                .name("TOURIST_HOTEL")
+                .build();
+
+            Accommodation accommodation = Accommodation.builder()
+                .name("그랜드 하얏트 제주")
+                .address(Address.builder()
+                    .address("제주특별자치도 제주시 노형동 925")
+                    .detailAddress("")
+                    .build())
+                .category(category)
+                .description(
+                    "63빌딩의 1.8배 규모인 연면적 30만 3737m2, 높이 169m(38층)를 자랑하는 제주 최대 높이, 최대 규모의 랜드마크이다. 제주 고도제한선(55m)보다 높이 위치한 1,600 올스위트 객실, 월드클래스 셰프들이 포진해 있는 14개의 글로벌 레스토랑 & 바, 인피니티 풀을 포함한 8층 야외풀데크, 38층 스카이데크를 비롯해 HAN컬렉션 K패션 쇼핑몰, 2개의 프리미엄 스파, 8개의 연회장 등 라스베이거스, 싱가포르, 마카오에서나 볼 수 있는 세계적인 수준의 복합리조트이다. 제주국제공항에서 차량으로 10분거리(5km)이며 제주의 강남이라고 불리는 신제주 관광 중심지에 위치하고 있다.")
+                .thumbnail("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+                .option(AccommodationOption.builder()
+                    .cooking(false)
+                    .parking(true)
+                    .pickup(false)
+                    .barbecue(false)
+                    .fitness(true)
+                    .karaoke(false)
+                    .sauna(false)
+                    .sports(true)
+                    .seminar(true)
+                    .build())
+                .images(new ArrayList<>())
+                .rooms(new ArrayList<>())
+                .build();
+
+            Room room = Room.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime(LocalTime.of(15, 0, 0))
+                .checkOutTime(LocalTime.of(11, 0, 0))
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(100000)
+                    .offWeekendMinFee(100000)
+                    .peakWeekDaysMinFee(100000)
+                    .peakWeekendMinFee(100000)
+                    .build())
+                .amount(858)
+                .status(RoomStatus.SELLING)
+                .option(RoomOption.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(new ArrayList<>())
+                .build();
+
+            RoomImage roomImage = RoomImage.builder()
+                .id(1L)
+                .room(room)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                .build();
+
+            Room savedRoom = Room.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime(LocalTime.of(15, 0, 0))
+                .checkOutTime(LocalTime.of(11, 0, 0))
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(100000)
+                    .offWeekendMinFee(100000)
+                    .peakWeekDaysMinFee(100000)
+                    .peakWeekendMinFee(100000)
+                    .build())
+                .amount(858)
+                .status(RoomStatus.SELLING)
+                .option(RoomOption.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(List.of(roomImage))
+                .build();
+
+            given(memberGetService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(accommodationQueryUseCase.getAccommodationById(any(Long.TYPE)))
+                .willReturn(accommodation);
+            given(accommodationQueryUseCase.existsOwnershipByMemberAndAccommodation(
+                any(Member.class),
+                any(Accommodation.class)))
+                .willReturn(true);
+            given(roomQueryUseCase.findAllByAccommodationId(any(Long.TYPE), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(savedRoom)));
+
+            // when
+            RoomPageResponse result = roomCommandService.getRooms(1L, 1L, roomPageRequest.of());
+
+            // then
+            assertThat(result.rooms().get(0).id()).isEqualTo(1L);
+            assertThat(result.rooms().get(0).name()).isEqualTo("65m² 킹룸");
+            assertThat(result.rooms().get(0).status()).isEqualTo("SELLING");
+            assertThat(result.rooms().get(0).defaultCapacity()).isEqualTo(2);
+            assertThat(result.rooms().get(0).maxCapacity()).isEqualTo(3);
+            assertThat(result.rooms().get(0).checkInTime()).isEqualTo("15:00");
+            assertThat(result.rooms().get(0).checkOutTime()).isEqualTo("11:00");
+            assertThat(result.rooms().get(0).price()).isEqualTo(100000);
+            assertThat(result.rooms().get(0).images()).isNotEmpty();
+            assertThat(result.rooms().get(0).images().get(0).id()).isEqualTo(1L);
+            assertThat(result.rooms().get(0).images().get(0).url()).isEqualTo(
+                "http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg");
+            assertThat(result.rooms().get(0).option()).isNotNull();
+            assertThat(result.rooms().get(0).option().airCondition()).isEqualTo(true);
+            assertThat(result.rooms().get(0).option().tv()).isEqualTo(true);
+            assertThat(result.rooms().get(0).option().internet()).isEqualTo(true);
+
+            verify(memberGetService, times(1)).getMemberById(any(Long.TYPE));
+            verify(accommodationQueryUseCase, times(1)).getAccommodationById(any(Long.TYPE));
+            verify(accommodationQueryUseCase, times(1))
+                .existsOwnershipByMemberAndAccommodation(
+                    any(Member.class),
+                    any(Accommodation.class)
+                );
+            verify(roomQueryUseCase, times(1))
+                .findAllByAccommodationId(any(Long.TYPE), any(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getRoom()은")
+    class Context_getRoom {
+
+        @Test
+        @DisplayName("객실을 조회할 수 있다.")
+        void _willSuccess() {
+            // given
+            RoomUpdateRequest roomUpdateRequest = RoomUpdateRequest.builder()
+                .name("65m² 킹룸")
+                .price(200000)
+                .status("STOP_SELLING")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime("15:00")
+                .checkOutTime("11:00")
+                .amount(858)
+                .addImages(List.of(RoomImageAddRequest.builder()
+                    .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                    .build()))
+                .deleteImages(List.of(RoomImageDeleteRequest.builder()
+                    .id(1L)
+                    .build()))
+                .option(RoomOptionRequest.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .build();
+
+            Member member = Member.builder()
+                .id(1L)
+                .email("test@mail.com")
+                .password("$10$ygrAExVYmFTkZn2d0.Pk3Ot5CNZwIBjZH5f.WW0AnUq4w4PtBi9Nm")
+                .name("test")
+                .phone("010-1234-1234")
+                .imageUrl(
+                    "https://fastly.picsum.photos/id/866/200/300.jpg?hmac=rcadCENKh4rD6MAp6V_ma-AyWv641M4iiOpe1RyFHeI")
+                .authority(Authority.ROLE_USER)
+                .build();
+
+            Category category = Category.builder()
+                .id(5L)
+                .name("TOURIST_HOTEL")
+                .build();
+
+            Accommodation accommodation = Accommodation.builder()
+                .name("그랜드 하얏트 제주")
+                .address(Address.builder()
+                    .address("제주특별자치도 제주시 노형동 925")
+                    .detailAddress("")
+                    .build())
+                .category(category)
+                .description(
+                    "63빌딩의 1.8배 규모인 연면적 30만 3737m2, 높이 169m(38층)를 자랑하는 제주 최대 높이, 최대 규모의 랜드마크이다. 제주 고도제한선(55m)보다 높이 위치한 1,600 올스위트 객실, 월드클래스 셰프들이 포진해 있는 14개의 글로벌 레스토랑 & 바, 인피니티 풀을 포함한 8층 야외풀데크, 38층 스카이데크를 비롯해 HAN컬렉션 K패션 쇼핑몰, 2개의 프리미엄 스파, 8개의 연회장 등 라스베이거스, 싱가포르, 마카오에서나 볼 수 있는 세계적인 수준의 복합리조트이다. 제주국제공항에서 차량으로 10분거리(5km)이며 제주의 강남이라고 불리는 신제주 관광 중심지에 위치하고 있다.")
+                .thumbnail("http://tong.visitkorea.or.kr/cms/resource/83/2876783_image2_1.jpg")
+                .option(AccommodationOption.builder()
+                    .cooking(false)
+                    .parking(true)
+                    .pickup(false)
+                    .barbecue(false)
+                    .fitness(true)
+                    .karaoke(false)
+                    .sauna(false)
+                    .sports(true)
+                    .seminar(true)
+                    .build())
+                .images(new ArrayList<>())
+                .rooms(new ArrayList<>())
+                .build();
+
+            RoomImage roomImage1 = RoomImage.builder()
+                .id(1L)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
+                .build();
+
+            Room room = Room.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime(LocalTime.of(15, 0, 0))
+                .checkOutTime(LocalTime.of(11, 0, 0))
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(100000)
+                    .offWeekendMinFee(100000)
+                    .peakWeekDaysMinFee(100000)
+                    .peakWeekendMinFee(100000)
+                    .build())
+                .amount(858)
+                .status(RoomStatus.SELLING)
+                .option(RoomOption.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(List.of(roomImage1))
+                .build();
+
+            RoomImage roomImage2 = RoomImage.builder()
+                .id(2L)
+                .room(room)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_2.jpg")
+                .build();
+            RoomImage roomImage3 = RoomImage.builder()
+                .id(3L)
+                .room(room)
+                .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_3.jpg")
+                .build();
+
+            Room savedRoom = Room.builder()
+                .id(1L)
+                .accommodation(accommodation)
+                .name("65m² 킹룸")
+                .defaultCapacity(2)
+                .maxCapacity(3)
+                .checkInTime(LocalTime.of(15, 0, 0))
+                .checkOutTime(LocalTime.of(11, 0, 0))
+                .price(RoomPrice.builder()
+                    .offWeekDaysMinFee(200000)
+                    .offWeekendMinFee(200000)
+                    .peakWeekDaysMinFee(200000)
+                    .peakWeekendMinFee(200000)
+                    .build())
+                .amount(858)
+                .status(RoomStatus.STOP_SELLING)
+                .option(RoomOption.builder()
+                    .airCondition(true)
+                    .tv(true)
+                    .internet(true)
+                    .build())
+                .images(List.of(roomImage2, roomImage3))
+                .build();
+
+            given(memberGetService.getMemberById(any(Long.TYPE))).willReturn(member);
+            given(roomQueryUseCase.findRoomById(any(Long.TYPE))).willReturn(room);
+            given(accommodationQueryUseCase.existsOwnershipByMemberAndAccommodation(
+                any(Member.class),
+                any(Accommodation.class)))
+                .willReturn(true);
+            given(roomQueryUseCase.saveRoomImages(any(List.class)))
+                .willReturn(List.of(roomImage2, roomImage3));
+            given(roomQueryUseCase.findRoomImage(any(Long.TYPE)))
+                .willReturn(roomImage1);
+            doNothing().when(roomQueryUseCase).deleteRoomImages(any(List.class));
+            given(roomQueryUseCase.findRoomById(any(Long.TYPE))).willReturn(savedRoom);
+
+            // when
+            RoomInfoResponse result = roomCommandService.modifyRoom(1L, 1L, roomUpdateRequest);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.name()).isEqualTo("65m² 킹룸");
+            assertThat(result.status()).isEqualTo("STOP_SELLING");
+            assertThat(result.defaultCapacity()).isEqualTo(2);
+            assertThat(result.maxCapacity()).isEqualTo(3);
+            assertThat(result.checkInTime()).isEqualTo("15:00");
+            assertThat(result.checkOutTime()).isEqualTo("11:00");
+            assertThat(result.price()).isEqualTo(200000);
+            assertThat(result.images()).isNotEmpty();
+            assertThat(result.images().get(0).id()).isEqualTo(2L);
+            assertThat(result.images().get(0).url()).isEqualTo(
+                "http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_2.jpg");
+            assertThat(result.option()).isNotNull();
+            assertThat(result.option().airCondition()).isEqualTo(true);
+            assertThat(result.option().tv()).isEqualTo(true);
+            assertThat(result.option().internet()).isEqualTo(true);
+
+            verify(memberGetService, times(1)).getMemberById(any(Long.TYPE));
+            verify(roomQueryUseCase, times(2)).findRoomById(any(Long.TYPE));
+            verify(accommodationQueryUseCase, times(1))
+                .existsOwnershipByMemberAndAccommodation(any(Member.class),
+                    any(Accommodation.class));
+            verify(roomQueryUseCase, times(1)).saveRoomImages(any(List.class));
+            verify(roomQueryUseCase, times(1)).findRoomImage(any(Long.TYPE));
+            verify(roomQueryUseCase, times(1)).deleteRoomImages(any(List.class));
         }
     }
 


### PR DESCRIPTION
### 💡Motivation
- 업주 회원이 소유한 숙소의 객실 목록 조회를 할 수 있도록 객실 목록 조회 기능을 구현해야 합니다. 
- 객실 수정 시 기존 객실의 정보가 표시되어야 하므로, 객실 상세 조회 기능을 구현해야 합니다. 

### 📌Changes
- 객실 목록 조회 기능 구현
- 객실 상세 조회 기능 구현
- 객실 목록/상세 조회 기능 테스트 작성
- 객실 목록/상세 조회 REST Docs 테스트 작성
- 객실 목록/상세 조회 API adoc 작성

### 🫱🏻‍🫲🏻To Reviewers
- 코드 리뷰와 승인 부탁 드려요~😊🌻

closes #68 