### PR TITLE
hotfix : 현재 로그인한 사용자 조회 기능 오류 수정 및 입점DB 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/entity/Owner.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/entity/Owner.java
@@ -1,11 +1,8 @@
 package com.backoffice.upjuyanolja.domain.member.entity;
 
-import static com.backoffice.upjuyanolja.domain.member.entity.Authority.ROLE_ADMIN;
 import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,10 +26,6 @@ public class Owner extends BaseTime {
     @Comment("이메일")
     private String email;
 
-    @Column(nullable = false)
-    @Comment("암호화된 비밀번호")
-    private String password;
-
     @Column(nullable = false, length = 30)
     @Comment("이름")
     private String name;
@@ -41,29 +34,15 @@ public class Owner extends BaseTime {
     @Comment("전화번호")
     private String phone;
 
-    @Column(columnDefinition = "TEXT")
-    @Comment("프로필 이미지 URL")
-    private String imageUrl;
-
-    @Enumerated(EnumType.STRING)
-    @Comment("권한")
-    private Authority authority = ROLE_ADMIN;
-
     @Builder
     public Owner(Long id,
         String email,
-        String password,
         String name,
-        String phone,
-        String imageUrl,
-        Authority authority
+        String phone
     ) {
         this.id = id;
         this.email = email;
-        this.password = password;
         this.name = name;
         this.phone = phone;
-        this.imageUrl = imageUrl;
-        this.authority = authority;
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/service/OwnerAuthService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/service/OwnerAuthService.java
@@ -14,6 +14,7 @@ import com.backoffice.upjuyanolja.domain.member.exception.CreateVerificationCode
 import com.backoffice.upjuyanolja.domain.member.exception.IncorrectPasswordException;
 import com.backoffice.upjuyanolja.domain.member.exception.IncorrectVerificationCodeException;
 import com.backoffice.upjuyanolja.domain.member.exception.InvalidRoleException;
+import com.backoffice.upjuyanolja.domain.member.exception.MemberEmailDuplicationException;
 import com.backoffice.upjuyanolja.domain.member.exception.MemberNotFoundException;
 import com.backoffice.upjuyanolja.domain.member.exception.NotRegisteredEmailException;
 import com.backoffice.upjuyanolja.domain.member.repository.MemberRepository;
@@ -54,6 +55,11 @@ public class OwnerAuthService implements
     private long authCodeExpirationMillis;
 
     public OwnerEmailResponse sendVerificationCodeToEmail(OwnerEmailRequest request) {
+
+        //이미 회원가입 된 상태인지 검증 (존재한다면 예외 발생)
+        if (memberRepository.existsByEmail(request.getEmail())){
+            throw new MemberEmailDuplicationException();
+        }
 
         //DB에 이미 존재하는 이메일인지 검증 (존재 해야 회원가입 가능)
         if (!ownerRepository.existsByEmail(request.getEmail())) {
@@ -114,7 +120,6 @@ public class OwnerAuthService implements
             .phone(ownerInfo.getPhone())
             .email(request.getEmail())
             .password(encoder.encode(request.getPassword()))
-            .imageUrl(ownerInfo.getImageUrl())
             .authority(ROLE_ADMIN)
             .build());
 

--- a/src/main/java/com/backoffice/upjuyanolja/global/security/SecurityUtil.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/security/SecurityUtil.java
@@ -1,12 +1,19 @@
 package com.backoffice.upjuyanolja.global.security;
 
+import com.backoffice.upjuyanolja.domain.member.entity.Member;
 import com.backoffice.upjuyanolja.domain.member.exception.AuthorizeInfoNotFoundException;
+import com.backoffice.upjuyanolja.domain.member.exception.MemberNotFoundException;
+import com.backoffice.upjuyanolja.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SecurityUtil {
+
+    private final MemberRepository memberRepository;
 
     public Long getCurrentMemberId() {
 
@@ -15,17 +22,9 @@ public class SecurityUtil {
         if (authentication == null || authentication.getName() == null) {
             throw new AuthorizeInfoNotFoundException();
         }
-        return Long.parseLong(authentication.getName());
-    }
-
-    public Long getNullableCurrentMemberId() {
-        final Authentication authentication = SecurityContextHolder.getContext()
-            .getAuthentication();
-        if (authentication == null || authentication.getName() == null || authentication.getName()
-            .equals("anonymousUser")) {
-            return null;
-        }
-
-        return Long.parseLong(authentication.getName());
+        Member member = memberRepository.findByEmail(authentication.getName()).orElseThrow(
+            MemberNotFoundException::new
+        );
+        return member.getId();
     }
 }


### PR DESCRIPTION
### 💡Motivation
- 현재 로그인한 사용자 조회 기능 오류 수정했습니다.
- 가상 입점 DB 테이블이 필요없는 (ERD 설계와 다르게 되어있던) 컬럼을 삭제했습니다. 

### 📌Changes
- Authentication에서 받아온 name이 email인데 Long으로 파싱하다보니, NumberFormatException이 발생했습니다.
- memberRepository를 의존성 추가하여, findByEmail로 Member 엔티티를 조회한 후 getId()로 Id를 반환하도록 수정했습니다.
- 입점DB역할을 하는 Owner 엔티티의 비밀번호 , 이미지 URL 필드를 삭제했습니다.

### 🫱🏻‍🫲🏻To Reviewers
- 다들 고생이 많으십니다. 추운데 감기 조심하세요