### PR TITLE
feat: 포인트 요약 조회

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/repository/AccommodationCustomRepositoryImpl.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/repository/AccommodationCustomRepositoryImpl.java
@@ -6,17 +6,15 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class AccommodationCustomRepositoryImpl implements AccommodationCustomRepository {
 
     private final JPAQueryFactory query;
     private final QAccommodation qAccommodation = QAccommodation.accommodation;
-
-    public AccommodationCustomRepositoryImpl(JPAQueryFactory query) {
-        this.query = query;
-    }
 
     @Override
     public List<Accommodation> findByCategoryWithTypeAndName(

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/controller/PointController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/controller/PointController.java
@@ -1,12 +1,48 @@
 package com.backoffice.upjuyanolja.domain.point.controller;
 
+import com.backoffice.upjuyanolja.domain.point.dto.response.PointSummaryResponse;
+import com.backoffice.upjuyanolja.domain.point.service.PointService;
+import com.backoffice.upjuyanolja.global.common.response.ApiResponse;
+import com.backoffice.upjuyanolja.global.common.response.ApiResponse.SuccessResponse;
+import com.backoffice.upjuyanolja.global.security.SecurityUtil;
+import java.time.YearMonth;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("api/points")
 @RequiredArgsConstructor
 public class PointController {
+
+    private final PointService pointService;
+    private final SecurityUtil securityUtil;
+
+    @GetMapping("/summary")
+    public ResponseEntity<SuccessResponse<PointSummaryResponse>> getSummary(
+        @RequestParam(required = true)
+        @DateTimeFormat(pattern = "yyyy-MM")
+        YearMonth rangeDate
+    ) {
+        log.info("GET /api/points/summary");
+
+        PointSummaryResponse response = pointService.getSummary(
+            securityUtil.getCurrentMemberId(), rangeDate
+        );
+        return ApiResponse.success(
+            HttpStatus.OK,
+            SuccessResponse.<PointSummaryResponse>builder()
+                .message("포인트 요약 조회에 성공 했습니다.")
+                .data(response)
+                .build()
+        );
+    }
 
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/dto/response/PointSummaryResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/dto/response/PointSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.backoffice.upjuyanolja.domain.point.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record PointSummaryResponse(
+    long chargePoint,
+    long usePoint,
+    long currentPoint
+) {
+
+    public static PointSummaryResponse of(
+        long chargePoint, long usePoint, long currentPoint
+    ) {
+        return PointSummaryResponse.builder()
+            .chargePoint(chargePoint)
+            .usePoint(usePoint)
+            .currentPoint(currentPoint)
+            .build();
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
@@ -57,4 +57,9 @@ public class Point extends BaseTime {
         this.member = member;
     }
 
+    public void updatePoint(Long pointBalance, YearMonth rangeDate){
+        this.pointBalance = pointBalance;
+        this.standardDate = rangeDate;
+    }
+
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
@@ -4,14 +4,13 @@ import com.backoffice.upjuyanolja.domain.member.entity.Member;
 import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.YearMonth;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,12 +29,11 @@ public class Point extends BaseTime {
 
     @Column(nullable = false)
     @Comment("보유 포인트")
-    private int pointBalance;
+    private long pointBalance;
 
     @Column(nullable = false)
-    @Enumerated(value = EnumType.STRING)
-    @Comment("포인트 유형")
-    private PointType pointType;
+    @Comment("기준 날짜")
+    private YearMonth standardDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -47,12 +45,12 @@ public class Point extends BaseTime {
     public Point(
         Long id,
         int pointBalance,
-        PointType pointType,
+        YearMonth standardDate,
         Member member
     ) {
         this.id = id;
         this.pointBalance = pointBalance;
-        this.pointType = pointType;
+        this.standardDate = standardDate;
         this.member = member;
     }
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/Point.java
@@ -1,8 +1,10 @@
 package com.backoffice.upjuyanolja.domain.point.entity;
 
 import com.backoffice.upjuyanolja.domain.member.entity.Member;
+import com.backoffice.upjuyanolja.domain.point.util.YearMonthConverter;
 import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -33,6 +35,7 @@ public class Point extends BaseTime {
 
     @Column(nullable = false)
     @Comment("기준 날짜")
+    @Convert(converter = YearMonthConverter.class)
     private YearMonth standardDate;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointCharges.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointCharges.java
@@ -4,6 +4,8 @@ import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,6 +33,11 @@ public class PointCharges extends BaseTime {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    @Comment("포인트 유형")
+    private PointType pointType;
+
+    @Column(nullable = false)
     @Comment("포인트 결제 키")
     private String paymentKey;
 
@@ -44,7 +51,7 @@ public class PointCharges extends BaseTime {
 
     @Column(nullable = false)
     @Comment("충전 포인트")
-    private int chargePoint;
+    private long chargePoint;
 
     @Column(nullable = false)
     @Comment("충전 일시")
@@ -69,6 +76,7 @@ public class PointCharges extends BaseTime {
     @Builder
     public PointCharges(
         Long id,
+        PointType pointType,
         String paymentKey,
         String paymentName,
         String orderName,
@@ -80,6 +88,7 @@ public class PointCharges extends BaseTime {
         List<PointRefunds> refunds
     ) {
         this.id = id;
+        this.pointType = pointType;
         this.paymentKey = paymentKey;
         this.paymentName = paymentName;
         this.orderName = orderName;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointRefunds.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointRefunds.java
@@ -3,6 +3,8 @@ package com.backoffice.upjuyanolja.domain.point.entity;
 import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,6 +29,11 @@ public class PointRefunds extends BaseTime {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    @Comment("포인트 유형")
+    private PointType pointType;
+
+    @Column(nullable = false)
     @Comment("환불 일시")
     private LocalDateTime refundDate;
 
@@ -43,11 +50,13 @@ public class PointRefunds extends BaseTime {
     @Builder
     public PointRefunds(
         Long id,
+        PointType pointType,
         LocalDateTime refundDate,
         Point point,
         PointCharges pointCharges
     ) {
         this.id = id;
+        this.pointType = pointType;
         this.refundDate = refundDate;
         this.point = point;
         this.pointCharges = pointCharges;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointType.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointType.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum PointType {
 
     CHARGE("충전"),
+    REFUND("충전"),
     USE("사용");
 
     private final String description;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointUsage.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointUsage.java
@@ -3,6 +3,8 @@ package com.backoffice.upjuyanolja.domain.point.entity;
 import com.backoffice.upjuyanolja.global.common.entity.BaseTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,6 +29,11 @@ public class PointUsage extends BaseTime {
     private Long id;
 
     @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    @Comment("포인트 유형")
+    private PointType pointType;
+
+    @Column(nullable = false)
     @Comment("주문 이름")
     private String orderName;
 
@@ -42,11 +49,13 @@ public class PointUsage extends BaseTime {
     @Builder
     public PointUsage(
         Long id,
+        PointType pointType,
         String orderName,
         LocalDateTime orderDate,
         Point point
     ) {
         this.id = id;
+        this.pointType = pointType;
         this.orderName = orderName;
         this.orderDate = orderDate;
         this.point = point;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointUsage.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/entity/PointUsage.java
@@ -41,6 +41,10 @@ public class PointUsage extends BaseTime {
     @Comment("주문 일시")
     private LocalDateTime orderDate;
 
+    @Column(nullable = false)
+    @Comment("주문 금액")
+    private long orderPrice;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "point_id")
     @Comment("포인트 식별자")
@@ -52,12 +56,14 @@ public class PointUsage extends BaseTime {
         PointType pointType,
         String orderName,
         LocalDateTime orderDate,
+        long orderPrice,
         Point point
     ) {
         this.id = id;
         this.pointType = pointType;
         this.orderName = orderName;
         this.orderDate = orderDate;
+        this.orderPrice = orderPrice;
         this.point = point;
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointChargesCustomRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointChargesCustomRepository.java
@@ -5,9 +5,9 @@ import com.backoffice.upjuyanolja.domain.point.entity.PointCharges;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PointChargesRepository extends JpaRepository<PointCharges, Long>,
-    PointChargesCustomRepository {
+public interface PointChargesCustomRepository {
 
+    List<PointCharges> findByPointAndRefundableAndChargeDateWithin(Point point,
+        YearMonth rangeDate);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointChargesCustomRepositoryImpl.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointChargesCustomRepositoryImpl.java
@@ -1,0 +1,47 @@
+package com.backoffice.upjuyanolja.domain.point.repository;
+
+import com.backoffice.upjuyanolja.domain.point.entity.Point;
+import com.backoffice.upjuyanolja.domain.point.entity.PointCharges;
+import com.backoffice.upjuyanolja.domain.point.entity.QPointCharges;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointChargesCustomRepositoryImpl implements PointChargesCustomRepository {
+
+    private final JPAQueryFactory query;
+    private final QPointCharges qPointCharges = QPointCharges.pointCharges;
+
+    @Override
+    public List<PointCharges> findByPointAndRefundableAndChargeDateWithin(
+        Point point, YearMonth rangeDate
+    ) {
+        List<PointCharges> result = getPointCharges(point, rangeDate);
+        return result;
+    }
+
+    private List<PointCharges> getPointCharges(
+        Point point, YearMonth rangeDate
+    ) {
+        return query.selectFrom(qPointCharges)
+            .where(qPointCharges.point.eq(point)
+                .and(qPointCharges.refundable.isTrue())
+                .and(eqChargeDate(rangeDate))
+            )
+            .fetch();
+    }
+
+    private BooleanExpression eqChargeDate(YearMonth rangeDate) {
+        BooleanExpression yearExpression =
+            qPointCharges.chargeDate.year().eq(rangeDate.getYear());
+        BooleanExpression monthExpression =
+            qPointCharges.chargeDate.month().eq(rangeDate.getMonthValue());
+
+        return yearExpression.and(monthExpression);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointRepository.java
@@ -1,8 +1,11 @@
 package com.backoffice.upjuyanolja.domain.point.repository;
 
 import com.backoffice.upjuyanolja.domain.point.entity.Point;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
+
+    Optional<Point> findByMemberId(Long id);
 
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageCustomRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageCustomRepository.java
@@ -4,9 +4,8 @@ import com.backoffice.upjuyanolja.domain.point.entity.Point;
 import com.backoffice.upjuyanolja.domain.point.entity.PointUsage;
 import java.time.YearMonth;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface PointUsageRepository extends JpaRepository<PointUsage, Long>, PointUsageCustomRepository {
+public interface PointUsageCustomRepository {
 
+    List<PointUsage> findByPointAndChargeDateWithin(Point point, YearMonth rangeDate);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageCustomRepositoryImpl.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageCustomRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.backoffice.upjuyanolja.domain.point.repository;
+
+import com.backoffice.upjuyanolja.domain.point.entity.Point;
+import com.backoffice.upjuyanolja.domain.point.entity.PointCharges;
+import com.backoffice.upjuyanolja.domain.point.entity.PointUsage;
+import com.backoffice.upjuyanolja.domain.point.entity.QPointCharges;
+import com.backoffice.upjuyanolja.domain.point.entity.QPointUsage;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PointUsageCustomRepositoryImpl implements PointUsageCustomRepository {
+
+    private final JPAQueryFactory query;
+    private final QPointUsage qPointUsage = QPointUsage.pointUsage;
+
+    @Override
+    public List<PointUsage> findByPointAndChargeDateWithin(
+        Point point, YearMonth rangeDate
+    ) {
+        List<PointUsage> result = getPointUsages(point, rangeDate);
+        return result;
+    }
+
+    private List<PointUsage> getPointUsages(
+        Point point, YearMonth rangeDate
+    ) {
+        return query.selectFrom(qPointUsage)
+            .where(qPointUsage.point.eq(point)
+                .and(eqChargeDate(rangeDate))
+            )
+            .fetch();
+    }
+
+    private BooleanExpression eqChargeDate(YearMonth rangeDate) {
+        BooleanExpression yearExpression =
+            qPointUsage.orderDate.year().eq(rangeDate.getYear());
+        BooleanExpression monthExpression =
+            qPointUsage.orderDate.month().eq(rangeDate.getMonthValue());
+
+        return yearExpression.and(monthExpression);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/service/PointService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/service/PointService.java
@@ -1,5 +1,15 @@
 package com.backoffice.upjuyanolja.domain.point.service;
 
+import com.backoffice.upjuyanolja.domain.member.service.MemberGetService;
+import com.backoffice.upjuyanolja.domain.point.dto.response.PointSummaryResponse;
+import com.backoffice.upjuyanolja.domain.point.entity.Point;
+import com.backoffice.upjuyanolja.domain.point.entity.PointCharges;
+import com.backoffice.upjuyanolja.domain.point.entity.PointUsage;
+import com.backoffice.upjuyanolja.domain.point.repository.PointChargesRepository;
+import com.backoffice.upjuyanolja.domain.point.repository.PointRepository;
+import com.backoffice.upjuyanolja.domain.point.repository.PointUsageRepository;
+import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +19,66 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PointService {
 
+    private final PointRepository pointRepository;
+    private final PointChargesRepository pointChargesRepository;
+    private final PointUsageRepository pointUsageRepository;
+    private final MemberGetService memberGetService;
+
+    public PointSummaryResponse getSummary(Long currentMemberId, YearMonth rangeDate) {
+        Point memberPoint = getMemberPoint(currentMemberId);
+        Long currentPoint =
+            getChargePoint(memberPoint, rangeDate) +
+                getChargePoint(memberPoint, rangeDate.minusMonths(1)) -
+                getUsePoint(memberPoint, rangeDate) -
+                getUsePoint(memberPoint, rangeDate.minusMonths(1));
+
+        updatePoint(memberPoint, currentPoint, rangeDate);
+
+        return PointSummaryResponse.builder()
+            .chargePoint(getChargePoint(memberPoint, rangeDate))
+            .usePoint(getUsePoint(memberPoint, rangeDate))
+            .currentPoint(currentPoint)
+            .build();
+    }
+
+    private Point getMemberPoint(Long currentMemberId) {
+        return pointRepository.findByMemberId(currentMemberId)
+            .orElseGet(() -> createPoint(currentMemberId));
+    }
+
+    private Point createPoint(Long currentMemberId) {
+        Point newPoint = Point.builder()
+            .pointBalance(0)
+            .standardDate(YearMonth.now())
+            .member(memberGetService.getMemberById(currentMemberId))
+            .build();
+
+        pointRepository.save(newPoint);
+
+        return newPoint;
+    }
+
+    private void updatePoint(Point point, Long pointBalance, YearMonth rangeDate){
+        point.updatePoint(pointBalance,rangeDate);
+        pointRepository.save(point);
+    }
+
+    private long getChargePoint(Point point, YearMonth rangeDate) {
+        return pointChargesRepository.findByPointAndRefundableAndChargeDateWithin(
+                point, rangeDate
+            ).stream()
+            .mapToLong(PointCharges::getChargePoint)
+            .sum();
+    }
+
+    private long getUsePoint(Point point, YearMonth rangeDate) {
+        List<PointUsage> byPointAndChargeDateWithin = pointUsageRepository.findByPointAndChargeDateWithin(
+            point, rangeDate
+        );
+        return pointUsageRepository.findByPointAndChargeDateWithin(
+                point, rangeDate
+            ).stream()
+            .mapToLong(PointUsage::getOrderPrice)
+            .sum();
+    }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/util/YearMonthConverter.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/util/YearMonthConverter.java
@@ -1,0 +1,25 @@
+package com.backoffice.upjuyanolja.domain.point.util;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.YearMonth;
+
+@Converter(autoApply = true)
+public class YearMonthConverter implements AttributeConverter<YearMonth, String> {
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.toString();
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        return YearMonth.parse(dbData);
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/coupon/select/coupon-getAll.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/coupon/select/coupon-getAll.http
@@ -1,2 +1,0 @@
-GET http://localhost:8080/api/coupons/backoffice?page=0
-Accept: application/json

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/member/insert/member-signUp.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/member/insert/member-signUp.http
@@ -4,6 +4,6 @@ Content-Type: application/json
 {
   "name": "test2",
   "phone": "010-1234-9876",
-  "email": "test@mail.com",
-  "password": "testPassword!!5432"
+  "email": "{{email}}",
+  "password": "{{password}}"
 }

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/member/insert/member-signUp.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/member/insert/member-signUp.http
@@ -1,0 +1,9 @@
+POST http://localhost:8080/api/auth/members/signup
+Content-Type: application/json
+
+{
+  "name": "test2",
+  "phone": "010-1234-9876",
+  "email": "test@mail.com",
+  "password": "testPassword!!5432"
+}

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/member/select/member-signIn.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/member/select/member-signIn.http
@@ -2,6 +2,16 @@ POST http://localhost:8080/api/auth/members/signin
 Content-Type: application/json
 
 {
-  "email": "test@mail.com",
-  "password": "testPassword!!5432"
+  "email": "{{email}}",
+  "password": "{{password}}"
 }
+
+> {%
+  client.test("Validate", function() {
+    client.assert(response.status === 200, "Response status is not 200");
+    client.assert(response.contentType.mimeType === "application/json", "Expected 'application/json'");
+  });
+
+  client.log(response.body.data.accessToken);
+  client.global.set("access_token",response.body.data.accessToken)
+%}

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/member/select/member-signIn.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/member/select/member-signIn.http
@@ -1,0 +1,7 @@
+POST http://localhost:8080/api/auth/members/signin
+Content-Type: application/json
+
+{
+  "email": "test@mail.com",
+  "password": "testPassword!!5432"
+}

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
@@ -1,2 +1,3 @@
-GET http://localhost:8080/api/points/summary
+GET http://localhost:8080/api/points/summary?rangeDate=2024-01
 Accept: application/json
+Authorization: Bearer {{access_token}}

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
@@ -1,0 +1,2 @@
+GET http://localhost:8080/api/points/summary
+Accept: application/json

--- a/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
+++ b/src/test/java/com/backoffice/upjuyanolja/httpTest/point/select/point-getSummary.http
@@ -1,3 +1,18 @@
+POST http://localhost:8080/api/auth/members/signin
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "{{password}}"
+}
+
+> {%
+  client.log(response.body.data.accessToken);
+  client.global.set("access_token",response.body.data.accessToken)
+%}
+
+###
+
 GET http://localhost:8080/api/points/summary?rangeDate=2024-01
 Accept: application/json
 Authorization: Bearer {{access_token}}


### PR DESCRIPTION
### 📌Changes
<img width="269" alt="image" src="https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/52107658/7907f9b6-6d61-4f53-8cc1-889aceefcf2d">

### 🫱🏻‍🫲🏻To Reviewers
- 환불은 프론트와 페이지에서 충전으로 보여지기 때문에 Enum 타입은 Refund인데 description은 충전으로 했습니다
- 시큐리티 필요한 조회를 http 테스트 코드 파일 하나로 처리할 수 있도록 했습니다
 point-getSummary.http 참고
- charge-use != current 
 current = charge - use + prev_charge임: 기획에서 지난 달의 이월 데이터도 가져와 달라고 함
- 포인트 엔터티의 pointBalance랑 standardDate가 포인트 도메인에서는 필요 없지만 일단 두고 update 메서드도 뒀습니다 
-> 다른 도메인에서도 필요 없다면 엔터티와 서비스 코드 모두에서 삭제할 예정
아니면 지금은 달마다 포인트인테 date 빼고 전체 포인트로 할지 고민중

close: #106 