### PR TITLE
Hotfix : 회원가입 관련 기능 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/MemberAuthController.java
@@ -8,6 +8,7 @@ import com.backoffice.upjuyanolja.domain.member.dto.response.MemberInfoResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.RefreshTokenResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.SignInResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.SignUpResponse;
+import com.backoffice.upjuyanolja.domain.member.dto.response.TokenResponse;
 import com.backoffice.upjuyanolja.domain.member.service.MemberAuthService;
 import com.backoffice.upjuyanolja.domain.member.service.MemberGetService;
 import com.backoffice.upjuyanolja.global.common.response.ApiResponse;
@@ -73,10 +74,10 @@ public class MemberAuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<SuccessResponse<RefreshTokenResponse>> refresh(
+    public ResponseEntity<SuccessResponse<TokenResponse>> refresh(
         @Valid @RequestBody TokenRequest request) {
         return ApiResponse.success(HttpStatus.OK,
-            SuccessResponse.<RefreshTokenResponse>builder()
+            SuccessResponse.<TokenResponse>builder()
                 .message("리프레쉬 토큰 재발급이 성공적으로 완료되었습니다.")
                 .data(memberAuthService.refresh(request))
                 .build());

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/OwnerAuthController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/OwnerAuthController.java
@@ -1,6 +1,7 @@
 package com.backoffice.upjuyanolja.domain.member.controller;
 
 import com.backoffice.upjuyanolja.domain.member.dto.request.OwnerEmailRequest;
+import com.backoffice.upjuyanolja.domain.member.dto.request.OwnerSignupRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.SignInRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.response.OwnerEmailResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.OwnerSignupResponse;
@@ -49,8 +50,8 @@ public class OwnerAuthController {
     }
 
     @PostMapping("owners/signup")
-    public ResponseEntity<SuccessResponse<OwnerSignupResponse>> ownerSingup(
-        @Valid @RequestBody OwnerEmailRequest request
+    public ResponseEntity<SuccessResponse<OwnerSignupResponse>> ownerSignup(
+        @Valid @RequestBody OwnerSignupRequest request
     ) {
         return ApiResponse.success(HttpStatus.OK,
             SuccessResponse.<OwnerSignupResponse>builder()
@@ -60,12 +61,12 @@ public class OwnerAuthController {
     }
 
     @PostMapping("owners/signin")
-    public ResponseEntity<SuccessResponse<SignInResponse>> ownerSingup(
+    public ResponseEntity<SuccessResponse<SignInResponse>> ownerSignup(
         @Valid @RequestBody SignInRequest request
     ) {
         return ApiResponse.success(HttpStatus.OK,
             SuccessResponse.<SignInResponse>builder()
-                .message("업주 회원가입이 성공적으로 완료되었습니다.")
+                .message("업주 로그인이 성공적으로 완료되었습니다.")
                 .data(ownerAuthService.signin(request))
                 .build());
     }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/OwnerAuthController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/OwnerAuthController.java
@@ -61,7 +61,7 @@ public class OwnerAuthController {
     }
 
     @PostMapping("owners/signin")
-    public ResponseEntity<SuccessResponse<SignInResponse>> ownerSignup(
+    public ResponseEntity<SuccessResponse<SignInResponse>> ownerSignIn(
         @Valid @RequestBody SignInRequest request
     ) {
         return ApiResponse.success(HttpStatus.OK,

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerEmailRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerEmailRequest.java
@@ -16,13 +16,9 @@ public class OwnerEmailRequest {
     @NotBlank
     private String email;
 
-    @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
-    private String password;
 
     @Builder
-    public OwnerEmailRequest(String email, String password) {
+    public OwnerEmailRequest(String email) {
         this.email = email;
-        this.password = password;
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerSignupRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerSignupRequest.java
@@ -18,28 +18,14 @@ public class OwnerSignupRequest {
     @NotBlank
     private String email;
 
-    @NotBlank(message = "이름을 입력해주세요")
-    @Size(min = 2, max = 12, message = "올바른 이름을 입력해주세요")
-    private String name;
-
     @NotBlank(message = "비밀번호를 입력해주세요")
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
 
-    @NotBlank
-    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호 양식에 맞지 않습니다.")
-    private String phone;
-
-    @Nullable
-    private String imageUrl;
 
     @Builder
-    public OwnerSignupRequest(String email, String name, String password, String phone,
-        @Nullable String imageUrl) {
+    public OwnerSignupRequest(String email, String password) {
         this.email = email;
-        this.name = name;
         this.password = password;
-        this.phone = phone;
-        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerSignupRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/OwnerSignupRequest.java
@@ -19,7 +19,7 @@ public class OwnerSignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~20자 영문 대 소문자, 숫자를 사용하세요.")
     private String password;
 
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignInRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignInRequest.java
@@ -17,7 +17,7 @@ public class SignInRequest {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\\\d)[a-zA-Z\\\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자를 사용하세요.")
     private String password;
 
     public UsernamePasswordAuthenticationToken toUsernamePasswordAuthenticationToken() {

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignInRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignInRequest.java
@@ -17,7 +17,7 @@ public class SignInRequest {
     private String email;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\\\d)[a-zA-Z\\\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~20자 영문 대 소문자, 숫자를 사용하세요.")
     private String password;
 
     public UsernamePasswordAuthenticationToken toUsernamePasswordAuthenticationToken() {

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
@@ -18,7 +18,7 @@ public record SignUpRequest(
     String name,
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자를 사용하세요.")
     String password,
 
     @NotBlank

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
@@ -18,7 +18,7 @@ public record SignUpRequest(
     String name,
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자를 사용하세요.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~20자 영문 대 소문자, 숫자를 사용하세요.")
     String password,
 
     @NotBlank

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/SignUpRequest.java
@@ -18,7 +18,7 @@ public record SignUpRequest(
     String name,
 
     @NotBlank(message = "비밀번호를 입력해주세요")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    @Pattern(regexp = "^[a-zA-Z\\d]{8,20}$", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     String password,
 
     @NotBlank

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/response/OwnerSignupResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/response/OwnerSignupResponse.java
@@ -18,15 +18,12 @@ public class OwnerSignupResponse {
 
     private String phone;
 
-    private String imageUrl;
-
     @Builder
-    public OwnerSignupResponse(Long id, String email, String name, String phone, String imageUrl) {
+    public OwnerSignupResponse(Long id, String email, String name, String phone) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.phone = phone;
-        this.imageUrl = imageUrl;
     }
 
     public static OwnerSignupResponse fromEntity(Member member) {
@@ -35,7 +32,6 @@ public class OwnerSignupResponse {
             .name(member.getName())
             .email(member.getEmail())
             .phone(member.getPhone())
-            .imageUrl(member.getImageUrl())
             .build();
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/exception/InvalidSignupProcessException.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/exception/InvalidSignupProcessException.java
@@ -1,0 +1,11 @@
+package com.backoffice.upjuyanolja.domain.member.exception;
+
+import com.backoffice.upjuyanolja.global.exception.ApplicationException;
+import com.backoffice.upjuyanolja.global.exception.ErrorCode;
+
+public class InvalidSignupProcessException extends ApplicationException {
+
+    public InvalidSignupProcessException() {
+        super(ErrorCode.INVALID_SIGNUP_PROCESS);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/service/OwnerAuthService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/service/OwnerAuthService.java
@@ -115,6 +115,14 @@ public class OwnerAuthService implements
 
     @Override
     public OwnerSignupResponse signup(OwnerSignupRequest request) {
+
+        //redis에서 이메일 인증이 완료된 상태인지 검증. 완료되지 않았다면 예외 발생
+        if (!redisService.getValues(request.getEmail()+EMAIL_VERIFY_DONE_FLAG).equals("true")){
+            throw new InvalidSignupProcessException();
+        }
+        redisService.deleteValues(request.getEmail()+EMAIL_VERIFY_DONE_FLAG);
+
+        //입점
         Owner ownerInfo = ownerRepository.findByEmail(request.getEmail()).orElseThrow(
             MemberNotFoundException::new
         );
@@ -127,10 +135,6 @@ public class OwnerAuthService implements
             .authority(ROLE_ADMIN)
             .build());
 
-        if (!redisService.getValues(request.getEmail()+EMAIL_VERIFY_DONE_FLAG).equals("true")){
-            throw new InvalidSignupProcessException();
-        }
-        redisService.deleteValues(request.getEmail()+EMAIL_VERIFY_DONE_FLAG);
 
         return OwnerSignupResponse.fromEntity(member);
     }

--- a/src/main/java/com/backoffice/upjuyanolja/global/exception/ErrorCode.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/exception/ErrorCode.java
@@ -19,8 +19,9 @@ public enum ErrorCode {
         "이메일 인증코드 생성 중 오류가 발생했습니다"),
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, 1009, "존재하지 않는 이메일입니다."),
     INCORRECT_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, 1010, "이메일 인증코드가 일치하지 않습니다."),
-    NOT_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, 1010, "입점 DB에 등록된 이메일이 아닙니다."),
-    INVALID_ROLE(HttpStatus.BAD_REQUEST, 1011, "유효한 권한이 아닙니다. 올바른 경로로 회원가입을 시도해주세요."),
+    NOT_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, 1011, "입점 DB에 등록된 이메일이 아닙니다."),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, 1012, "유효한 권한이 아닙니다. 올바른 경로로 회원가입을 시도해주세요."),
+    INVALID_SIGNUP_PROCESS(HttpStatus.BAD_REQUEST, 1013, "이메일 인증을 진행 한 뒤 회원가입을 시도하세요."),
 
     // Accommodation
     ACCOMMODATION_NOT_FOUND(HttpStatus.NOT_FOUND, 2000, "숙소 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/backoffice/upjuyanolja/global/exception/ErrorCode.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode {
     INCORRECT_EMAIL(HttpStatus.BAD_REQUEST, 1003, "이메일이 일치하지 않습니다."),
     INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, 1004, "비밀번호가 일치하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 1005, "회원 정보를 찾을 수 없습니다."),
-    AUTHORIZE_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, 1006, "인증 정보를 찾을 수 없습니다"),
+    AUTHORIZE_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, 1006, "인증 정보를 찾을 수 없습니다."),
     EMAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1007, "이메일 인증코드 발송 중 오류가 발생했습니다"),
     CREATE_VERIFICATION_CODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 1008,
         "이메일 인증코드 생성 중 오류가 발생했습니다"),

--- a/src/main/java/com/backoffice/upjuyanolja/global/security/SecurityUtil.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/security/SecurityUtil.java
@@ -1,16 +1,21 @@
 package com.backoffice.upjuyanolja.global.security;
 
+import static org.springframework.util.StringUtils.*;
+
 import com.backoffice.upjuyanolja.domain.member.entity.Member;
 import com.backoffice.upjuyanolja.domain.member.exception.AuthorizeInfoNotFoundException;
 import com.backoffice.upjuyanolja.domain.member.exception.MemberNotFoundException;
 import com.backoffice.upjuyanolja.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityUtil {
 
     private final MemberRepository memberRepository;
@@ -19,9 +24,11 @@ public class SecurityUtil {
 
         final Authentication authentication = SecurityContextHolder.getContext()
             .getAuthentication();
-        if (authentication == null || authentication.getName() == null) {
+
+        if (authentication == null || !hasText(authentication.getName()) || authentication.getName().equals("anonymousUser")) {
             throw new AuthorizeInfoNotFoundException();
         }
+        log.info("getName is {}", authentication.getName());
         Member member = memberRepository.findByEmail(authentication.getName()).orElseThrow(
             MemberNotFoundException::new
         );


### PR DESCRIPTION
### 💡Motivation
- 이메일 중복 검사에서 password를 요구하지 않도록 DTO 따로 생성해달라는 요청이 있었습니다.
- 비밀번호 정규표현식 수정해달라는 요청이 있었습니다.
- 회원 가입 시 휴대폰 번호 받지 않도록 수정해달라는 요청이 있었습니다.
- 이메일 인증 번호 요청 시 이메일 중복 여부 검사 추가해달라는 요청이 있었습니다.

### 📌Changes
- 이메일 인증코드 API 요청 시 비밀번호를 받지 않고 이메일만 받도록 DTO를 재정의 했습니다.
- 비밀번호 정규표현식에 포함되어 있던 특수문자를 제외하고 영어 대소문자와 숫자로만 구성된 8 ~ 20자 사이의 비밀번호로 수정했습니다.
- 회원가입 시 휴대폰 번호는 입점DB에서 파싱합니다.
- 이메일 인증번호 요청 시 이미 가입 된 이메일이라면 DuplicateEmailException이 발생하도록 수정했습니다.
+ 추가로 이메일 인증이 진행되지 않은 경우에도 가입요청 API를 호출했을 때 이메일 인증이 진행되었는지에 대한 상태를 모르기 때문에 정상적으로 가입이 되는 로직 오류가 발생했습니다. Redis를 활용하여 이메일 인증이 되었는지에 대한 여부를 저장함으로써 해결하였습니다.
### 🫱🏻‍🫲🏻To Reviewers
- 주말 잘 보내세요