### PR TITLE
refactor: 예약 목록 조회 원형에 필터 목적의 status 쿼리 파라미터 사용하도록 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetCanceledResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetCanceledResponse.java
@@ -1,100 +1,12 @@
 package com.backoffice.upjuyanolja.domain.reservation.dto.response;
 
-import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
-import com.backoffice.upjuyanolja.domain.payment.entity.Payment;
 import com.backoffice.upjuyanolja.domain.reservation.entity.Reservation;
-import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationRoom;
-import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationStatus;
-import com.backoffice.upjuyanolja.domain.reservation.exception.NoSuchReservationRoomException;
-import com.backoffice.upjuyanolja.domain.room.entity.Room;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import lombok.Getter;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
-@Getter
-public class GetCanceledResponse {
+public class GetCanceledResponse extends GetReservationResponse {
 
-    private final Integer pageNum;
-    private final Integer pageSize;
-    private final Integer totalPages;
-    private final Long totalElements;
-    private final Boolean isLast;
-
-    private final List<ReservationDTO> reservations;
 
     public GetCanceledResponse(Page<Reservation> reservations) {
-        if (reservations == null) {
-            this.pageNum = null;
-            this.pageSize = null;
-            this.totalPages = null;
-            this.totalElements = null;
-            this.isLast = null;
-            this.reservations = null;
-        } else {
-            Pageable pageable = reservations.getPageable();
-            this.pageNum = pageable.getPageNumber();
-            this.pageSize = pageable.getPageSize();
-            this.totalPages = reservations.getTotalPages();
-            this.totalElements = reservations.getTotalElements();
-            this.isLast = reservations.isLast();
-            this.reservations = reservations.stream().map(ReservationDTO::new).toList();
-        }
-    }
-
-    @Getter
-    public class ReservationDTO {
-
-        private final Long id;
-        private final LocalDate date;
-        private final Boolean isCouponUsed;
-        private final int roomPrice;
-        private final int totalAmount;
-        private final Long accommodationId;
-        private final String accommodationName;
-        private final Long roomId;
-        private final String roomName;
-        private final LocalTime checkInTime;
-        private final LocalTime checkOutTime;
-        private final int defaultCapacity;
-        private final int maxCapacity;
-        private final LocalDate startDate;
-        private final LocalDate endDate;
-        private final ReservationStatus status;
-
-        public ReservationDTO(Reservation reservation) {
-            Payment payment = reservation.getPayment();
-            LocalDateTime createdAt = reservation.getCreatedAt();
-
-            this.id = reservation.getId();
-            this.date = createdAt == null ? null : createdAt.toLocalDate();
-            this.isCouponUsed = reservation.getIsCouponUsed();
-            this.roomPrice = payment.getRoomPrice();
-            this.totalAmount = payment.getTotalAmount();
-            this.status = reservation.getStatus();
-
-            try {
-                ReservationRoom reservationRoom = reservation.getReservationRoom();
-                Room room = reservationRoom.getRoom();
-                Accommodation accommodation = room.getAccommodation();
-
-                this.accommodationId = accommodation.getId();
-                this.accommodationName = accommodation.getName();
-                this.roomId = room.getId();
-                this.roomName = room.getName();
-                this.checkInTime = room.getCheckInTime();
-                this.checkOutTime = room.getCheckOutTime();
-                this.defaultCapacity = room.getDefaultCapacity();
-                this.maxCapacity = room.getMaxCapacity();
-                this.startDate = reservationRoom.getStartDate();
-                this.endDate = reservationRoom.getEndDate();
-
-            } catch (NullPointerException e) {
-                throw new NoSuchReservationRoomException();
-            }
-        }
+        super(reservations);
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetReservationResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetReservationResponse.java
@@ -1,0 +1,101 @@
+package com.backoffice.upjuyanolja.domain.reservation.dto.response;
+
+import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
+import com.backoffice.upjuyanolja.domain.payment.entity.Payment;
+import com.backoffice.upjuyanolja.domain.reservation.entity.Reservation;
+import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationRoom;
+import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationStatus;
+import com.backoffice.upjuyanolja.domain.reservation.exception.NoSuchReservationRoomException;
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+public class GetReservationResponse {
+
+    private final Integer pageNum;
+    private final Integer pageSize;
+    private final Integer totalPages;
+    private final Long totalElements;
+    private final Boolean isLast;
+
+    private final List<GetReservationResponse.ReservationDTO> reservations;
+
+    public GetReservationResponse(Page<Reservation> reservations) {
+        if (reservations == null) {
+            this.pageNum = null;
+            this.pageSize = null;
+            this.totalPages = null;
+            this.totalElements = null;
+            this.isLast = null;
+            this.reservations = null;
+        } else {
+            Pageable pageable = reservations.getPageable();
+            this.pageNum = pageable.getPageNumber();
+            this.pageSize = pageable.getPageSize();
+            this.totalPages = reservations.getTotalPages();
+            this.totalElements = reservations.getTotalElements();
+            this.isLast = reservations.isLast();
+            this.reservations = reservations.stream()
+                .map(GetReservationResponse.ReservationDTO::new).toList();
+        }
+    }
+
+    @Getter
+    public class ReservationDTO {
+
+        private final Long id;
+        private final LocalDate date;
+        private final Boolean isCouponUsed;
+        private final int roomPrice;
+        private final int totalAmount;
+        private final Long accommodationId;
+        private final String accommodationName;
+        private final Long roomId;
+        private final String roomName;
+        private final LocalTime checkInTime;
+        private final LocalTime checkOutTime;
+        private final int defaultCapacity;
+        private final int maxCapacity;
+        private final LocalDate startDate;
+        private final LocalDate endDate;
+        private final ReservationStatus status;
+
+        public ReservationDTO(Reservation reservation) {
+            Payment payment = reservation.getPayment();
+            LocalDateTime createdAt = reservation.getCreatedAt();
+
+            this.id = reservation.getId();
+            this.date = createdAt == null ? null : createdAt.toLocalDate();
+            this.isCouponUsed = reservation.getIsCouponUsed();
+            this.roomPrice = payment.getRoomPrice();
+            this.totalAmount = payment.getTotalAmount();
+            this.status = reservation.getStatus();
+
+            try {
+                ReservationRoom reservationRoom = reservation.getReservationRoom();
+                Room room = reservationRoom.getRoom();
+                Accommodation accommodation = room.getAccommodation();
+
+                this.accommodationId = accommodation.getId();
+                this.accommodationName = accommodation.getName();
+                this.roomId = room.getId();
+                this.roomName = room.getName();
+                this.checkInTime = room.getCheckInTime();
+                this.checkOutTime = room.getCheckOutTime();
+                this.defaultCapacity = room.getDefaultCapacity();
+                this.maxCapacity = room.getMaxCapacity();
+                this.startDate = reservationRoom.getStartDate();
+                this.endDate = reservationRoom.getEndDate();
+
+            } catch (NullPointerException e) {
+                throw new NoSuchReservationRoomException();
+            }
+        }
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetReservedResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/dto/response/GetReservedResponse.java
@@ -1,100 +1,12 @@
 package com.backoffice.upjuyanolja.domain.reservation.dto.response;
 
-import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
-import com.backoffice.upjuyanolja.domain.payment.entity.Payment;
 import com.backoffice.upjuyanolja.domain.reservation.entity.Reservation;
-import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationRoom;
-import com.backoffice.upjuyanolja.domain.reservation.entity.ReservationStatus;
-import com.backoffice.upjuyanolja.domain.reservation.exception.NoSuchReservationRoomException;
-import com.backoffice.upjuyanolja.domain.room.entity.Room;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import lombok.Getter;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
-@Getter
-public class GetReservedResponse {
-
-    private final Integer pageNum;
-    private final Integer pageSize;
-    private final Integer totalPages;
-    private final Long totalElements;
-    private final Boolean isLast;
-
-    private final List<ReservationDTO> reservations;
+public class GetReservedResponse extends GetReservationResponse {
 
     public GetReservedResponse(Page<Reservation> reservations) {
-        if (reservations == null) {
-            this.pageNum = null;
-            this.pageSize = null;
-            this.totalPages = null;
-            this.totalElements = null;
-            this.isLast = null;
-            this.reservations = null;
-        } else {
-            Pageable pageable = reservations.getPageable();
-            this.pageNum = pageable.getPageNumber();
-            this.pageSize = pageable.getPageSize();
-            this.totalPages = reservations.getTotalPages();
-            this.totalElements = reservations.getTotalElements();
-            this.isLast = reservations.isLast();
-            this.reservations = reservations.stream().map(ReservationDTO::new).toList();
-        }
+        super(reservations);
     }
 
-    @Getter
-    public class ReservationDTO {
-
-        private final Long id;
-        private final LocalDate date;
-        private final Boolean isCouponUsed;
-        private final int roomPrice;
-        private final int totalAmount;
-        private final Long accommodationId;
-        private final String accommodationName;
-        private final Long roomId;
-        private final String roomName;
-        private final LocalTime checkInTime;
-        private final LocalTime checkOutTime;
-        private final int defaultCapacity;
-        private final int maxCapacity;
-        private final LocalDate startDate;
-        private final LocalDate endDate;
-        private final ReservationStatus status;
-
-        public ReservationDTO(Reservation reservation) {
-            Payment payment = reservation.getPayment();
-            LocalDateTime createdAt = reservation.getCreatedAt();
-
-            this.id = reservation.getId();
-            this.date = createdAt == null ? null : createdAt.toLocalDate();
-            this.isCouponUsed = reservation.getIsCouponUsed();
-            this.roomPrice = payment.getRoomPrice();
-            this.totalAmount = payment.getTotalAmount();
-            this.status = reservation.getStatus();
-
-            try {
-                ReservationRoom reservationRoom = reservation.getReservationRoom();
-                Room room = reservationRoom.getRoom();
-                Accommodation accommodation = room.getAccommodation();
-
-                this.accommodationId = accommodation.getId();
-                this.accommodationName = accommodation.getName();
-                this.roomId = room.getId();
-                this.roomName = room.getName();
-                this.checkInTime = room.getCheckInTime();
-                this.checkOutTime = room.getCheckOutTime();
-                this.defaultCapacity = room.getDefaultCapacity();
-                this.maxCapacity = room.getMaxCapacity();
-                this.startDate = reservationRoom.getStartDate();
-                this.endDate = reservationRoom.getEndDate();
-
-            } catch (NullPointerException e) {
-                throw new NoSuchReservationRoomException();
-            }
-        }
-    }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/reservation/docs/ReservationControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/reservation/docs/ReservationControllerDocsTest.java
@@ -394,7 +394,8 @@ public class ReservationControllerDocsTest extends RestDocsSupport {
 
         // when
         ResultActions result = mockMvc.perform(
-            MockMvcRequestBuilders.get("/api/reservations/cancel")
+            MockMvcRequestBuilders.get("/api/reservations")
+                .queryParam("status", "CANCELLED")
                 .queryParam("page", String.valueOf(pageable.getPageNumber()))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -402,7 +403,9 @@ public class ReservationControllerDocsTest extends RestDocsSupport {
         result.andExpect(status().isOk())
             .andDo(restDoc.document(
                 queryParameters(
-                    parameterWithName("page").description("불러올 페이지 순서")),
+                    parameterWithName("status").description("조회할 예약 상태"),
+                    parameterWithName("page").description("불러올 페이지 순서")
+                ),
                 responseFields(
                     fieldWithPath("message").description("응답 메세지"),
                     subsectionWithPath("data").description("응답 데이터"),

--- a/src/test/java/com/backoffice/upjuyanolja/domain/reservation/unit/controller/ReservationControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/reservation/unit/controller/ReservationControllerTest.java
@@ -403,7 +403,8 @@ class ReservationControllerTest {
 
             // when
             // then
-            mockMvc.perform(MockMvcRequestBuilders.get("/api/reservations/cancel")
+            mockMvc.perform(MockMvcRequestBuilders.get("/api/reservations")
+                    .queryParam("status", "CANCELLED")
                     .param("page", String.valueOf(pageable.getPageNumber()))
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is(HttpStatus.OK.value()))


### PR DESCRIPTION
### 💡Motivation
중간 피드백에서 받은 피드백을 바탕으로 URI 리팩토링

### 📌Changes
이전: GET /api/reservations/cancel?page=0
변경: GET /api/reservations?status=CANCELLED&page={pageNo}

### 🫱🏻‍🫲🏻To Reviewers
![image](https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/65496092/0b97713b-7290-4c1e-acc7-be2f80b39e5b)