### PR TITLE
refactor: 이메일 중복 검사 API를 POST 요청으로 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/MemberAuthController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/controller/MemberAuthController.java
@@ -1,5 +1,6 @@
 package com.backoffice.upjuyanolja.domain.member.controller;
 
+import com.backoffice.upjuyanolja.domain.member.dto.request.EmailRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.SignInRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.SignUpRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.TokenRequest;
@@ -29,7 +30,7 @@ public class MemberAuthController {
 
     private final MemberAuthService memberAuthService;
     private final MemberGetService memberGetService;
-    private final SecurityUtil securityUtill;
+    private final SecurityUtil securityUtil;
 
     @PostMapping("members/signup")
     public ResponseEntity<SignUpResponse> signup(
@@ -39,11 +40,11 @@ public class MemberAuthController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @GetMapping("members/email")
+    @PostMapping("members/email")
     public ResponseEntity<CheckEmailDuplicateResponse> checkEmailDuplicate(
-        @RequestParam(name = "email") String email
+        @RequestBody EmailRequest request
     ) {
-        CheckEmailDuplicateResponse response = memberAuthService.checkEmailDuplicate(email);
+        CheckEmailDuplicateResponse response = memberAuthService.checkEmailDuplicate(request);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -58,7 +59,7 @@ public class MemberAuthController {
     @GetMapping("members")
     public ResponseEntity<MemberInfoResponse> getMember() {
         MemberInfoResponse response = memberGetService.getMember(
-            securityUtill.getCurrentMemberId());
+            securityUtil.getCurrentMemberId());
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/EmailRequest.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/dto/request/EmailRequest.java
@@ -1,0 +1,14 @@
+package com.backoffice.upjuyanolja.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+
+@Builder
+public record EmailRequest(
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "이메일 형식에 맞게 입력해주세요.")
+    String email
+) {
+
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/member/service/MemberAuthService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/member/service/MemberAuthService.java
@@ -2,11 +2,11 @@ package com.backoffice.upjuyanolja.domain.member.service;
 
 import static com.backoffice.upjuyanolja.domain.member.entity.Authority.ROLE_USER;
 
+import com.backoffice.upjuyanolja.domain.member.dto.request.EmailRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.SignInRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.SignUpRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.request.TokenRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.response.CheckEmailDuplicateResponse;
-import com.backoffice.upjuyanolja.domain.member.dto.response.RefreshTokenResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.SignInResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.SignUpResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.TokenResponse;
@@ -103,9 +103,9 @@ public class MemberAuthService implements AuthServiceProvider<SignUpResponse, Si
         }
     }
 
-    public CheckEmailDuplicateResponse checkEmailDuplicate(String email) {
+    public CheckEmailDuplicateResponse checkEmailDuplicate(EmailRequest request) {
         return CheckEmailDuplicateResponse.builder()
-            .isExists(isDuplicatedEmail(email))
+            .isExists(isDuplicatedEmail(request.email()))
             .build();
     }
 
@@ -127,7 +127,7 @@ public class MemberAuthService implements AuthServiceProvider<SignUpResponse, Si
 
         // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
         String refreshToken = redisService.getValues(authentication.getName());
-        if (refreshToken.equals("false")){
+        if (refreshToken.equals("false")) {
             throw new LoggedOutMemberException();
         }
 

--- a/src/main/java/com/backoffice/upjuyanolja/global/security/AuthenticationConfig.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/security/AuthenticationConfig.java
@@ -33,8 +33,8 @@ public class AuthenticationConfig {
         "/api/open-api"
     };
     private static final String[] PERMIT_OWNER_URL_ARRAY = {
-        "/api/accommodations/backoffice",
-        "/api/coupons/backoffice",
+        "/api/accommodations/backoffice/**",
+        "/api/coupons/backoffice/**",
         "/api/points/**",
         "/api/rooms/**"
     };

--- a/src/test/java/com/backoffice/upjuyanolja/domain/member/docs/MemberAuthControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/member/docs/MemberAuthControllerDocsTest.java
@@ -5,11 +5,14 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 
+import com.backoffice.upjuyanolja.domain.member.dto.request.EmailRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.response.CheckEmailDuplicateResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.MemberInfoResponse;
 import com.backoffice.upjuyanolja.domain.member.service.MemberAuthService;
@@ -19,6 +22,7 @@ import com.backoffice.upjuyanolja.global.util.RestDocsSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -38,19 +42,23 @@ public class MemberAuthControllerDocsTest extends RestDocsSupport {
     @DisplayName("checkEmailDuplicate()는 이메일 중복 검사를 할 수 있다.")
     void checkEmailDuplicate() throws Exception {
         // given
+        EmailRequest request = EmailRequest.builder()
+            .email("test@mail.com")
+            .build();
         CheckEmailDuplicateResponse checkEmailDuplicateResponse = CheckEmailDuplicateResponse.builder()
             .isExists(true)
             .build();
 
-        given(memberAuthService.checkEmailDuplicate(any(String.class)))
+        given(memberAuthService.checkEmailDuplicate(any(EmailRequest.class)))
             .willReturn(checkEmailDuplicateResponse);
 
         // when then
-        mockMvc.perform(get("/api/auth/members/email")
-                .queryParam("email", "test@mail.com"))
+        mockMvc.perform(post("/api/auth/members/email")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON))
             .andDo(restDoc.document(
-                queryParameters(
-                    parameterWithName("email").description("이메일")
+                requestFields(
+                    fieldWithPath("email").description("이메일")
                 ),
                 responseFields(
                     fieldWithPath("isExists").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/com/backoffice/upjuyanolja/domain/member/unit/controller/MemberAuthControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/member/unit/controller/MemberAuthControllerTest.java
@@ -5,11 +5,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.backoffice.upjuyanolja.domain.member.controller.MemberAuthController;
+import com.backoffice.upjuyanolja.domain.member.dto.request.EmailRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.response.CheckEmailDuplicateResponse;
 import com.backoffice.upjuyanolja.domain.member.dto.response.MemberInfoResponse;
 import com.backoffice.upjuyanolja.domain.member.service.MemberAuthService;
@@ -27,6 +29,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -61,42 +64,50 @@ public class MemberAuthControllerTest {
         @DisplayName("이메일 중복일 경우 isExists를 true로 응답할 수 있다.")
         void duplicatedEmail_willSuccess() throws Exception {
             // given
+            EmailRequest request = EmailRequest.builder()
+                .email("test@mail.com")
+                .build();
             CheckEmailDuplicateResponse checkEmailDuplicateResponse = CheckEmailDuplicateResponse.builder()
                 .isExists(true)
                 .build();
 
-            given(memberAuthService.checkEmailDuplicate(any(String.class)))
+            given(memberAuthService.checkEmailDuplicate(any(EmailRequest.class)))
                 .willReturn(checkEmailDuplicateResponse);
 
             // when then
-            mockMvc.perform(get("/api/auth/members/email")
-                    .queryParam("email", "test@mail.com"))
+            mockMvc.perform(post("/api/auth/members/email")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isExists").isBoolean())
                 .andDo(print());
 
-            verify(memberAuthService, times(1)).checkEmailDuplicate(any(String.class));
+            verify(memberAuthService, times(1)).checkEmailDuplicate(any(EmailRequest.class));
         }
 
         @Test
         @DisplayName("이메일 중복이 아닐 경우 isExists를 false로 응답할 수 있다.")
         void notDuplicatedEmail_willSuccess() throws Exception {
             // given
+            EmailRequest request = EmailRequest.builder()
+                .email("test@mail.com")
+                .build();
             CheckEmailDuplicateResponse checkEmailDuplicateResponse = CheckEmailDuplicateResponse.builder()
                 .isExists(false)
                 .build();
 
-            given(memberAuthService.checkEmailDuplicate(any(String.class)))
+            given(memberAuthService.checkEmailDuplicate(any(EmailRequest.class)))
                 .willReturn(checkEmailDuplicateResponse);
 
             // when then
-            mockMvc.perform(get("/api/auth/members/email")
-                    .queryParam("email", "test@mail.com"))
+            mockMvc.perform(post("/api/auth/members/email")
+                    .content(objectMapper.writeValueAsString(request))
+                    .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isExists").isBoolean())
                 .andDo(print());
 
-            verify(memberAuthService, times(1)).checkEmailDuplicate(any(String.class));
+            verify(memberAuthService, times(1)).checkEmailDuplicate(any(EmailRequest.class));
         }
     }
 

--- a/src/test/java/com/backoffice/upjuyanolja/domain/member/unit/service/MemberAuthServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/member/unit/service/MemberAuthServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.backoffice.upjuyanolja.domain.member.dto.request.EmailRequest;
 import com.backoffice.upjuyanolja.domain.member.dto.response.CheckEmailDuplicateResponse;
 import com.backoffice.upjuyanolja.domain.member.repository.MemberRepository;
 import com.backoffice.upjuyanolja.domain.member.service.MemberAuthService;
@@ -37,11 +38,15 @@ public class MemberAuthServiceTest {
         @DisplayName("이메일이 존재하면 isExists에 true를 담아 반환한다.")
         void isExists_willSuccess() {
             // given
+            EmailRequest emailRequest = EmailRequest.builder()
+                .email("test@mail.com")
+                .build();
+
             given(memberRepository.existsByEmail(any(String.class))).willReturn(true);
 
             // when
-            CheckEmailDuplicateResponse result = memberAuthService.checkEmailDuplicate(
-                "test@mail.com");
+            CheckEmailDuplicateResponse result = memberAuthService
+                .checkEmailDuplicate(emailRequest);
 
             // then
             assertTrue(result.isExists());
@@ -53,11 +58,15 @@ public class MemberAuthServiceTest {
         @DisplayName("이메일이 존재하면 isExists에 false를 담아 반환한다.")
         void isNotExists_willSuccess() {
             // given
+            EmailRequest emailRequest = EmailRequest.builder()
+                .email("test@mail.com")
+                .build();
+
             given(memberRepository.existsByEmail(any(String.class))).willReturn(false);
 
             // when
             CheckEmailDuplicateResponse result = memberAuthService.checkEmailDuplicate(
-                "test@mail.com");
+                emailRequest);
 
             // then
             assertFalse(result.isExists());


### PR DESCRIPTION
### 💡Motivation
- 이메일 중복 검사 시 GET, 쿼리 파라미터로 이메일을 받게 되면 경유하는 인스턴스에 access log를 남길 수 있으므로, 보안상 좋은 방법이 아닙니다. 
- 따라서 이메일 중복 검사 API를 POST 요청으로 바꾸고, Request Body로 이메일을 받도록 수정해야 합니다. 

### 📌Changes
- 이메일 중복 검사 API를 POST 요청으로 수정

### 🫱🏻‍🫲🏻To Reviewers
- 리뷰 부탁 드립니다~😊

closes #148 