### PR TITLE
Fix: roomStocks sort 전 가변 객체로 변환

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
@@ -29,6 +29,7 @@ import com.backoffice.upjuyanolja.domain.room.repository.RoomRepository;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -127,8 +128,9 @@ public class ReservationService {
             throw new InvalidReservationInfoException();
         }
 
-        roomStocks.sort(Comparator.comparing(RoomStock::getDate));
-        return roomStocks;
+        List<RoomStock> modifiableRoomStocks = new ArrayList<>(roomStocks);
+        modifiableRoomStocks.sort(Comparator.comparing(RoomStock::getDate));
+        return modifiableRoomStocks;
     }
 
     private Coupon decreaseCouponStock(Coupon coupon) {


### PR DESCRIPTION
### 💡Motivation
![image](https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/65496092/096654a5-e8f7-485c-9d62-eefa2956a5d4)

roomCommandUseCase.getFilteredRoomStocksByDate()로 받아온 roomStocks를
sort 하는 과정에서 UnsupportedOperationException 발생

java.lang.UnsupportedOperationException은 수정할 수 없는 개체를 수정하려는 경우 발생

Test code 에서는 직접 생성한 mock list였기 때문에 해당 에러가 발생하지 않은 것으로 추정

### 📌Changes
- roomStocks sort 전 가변 객체로 변환

### 🫱🏻‍🫲🏻To Reviewers

close #150