### PR TITLE
Fix: 트랜젝션 롤백 에러 

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
@@ -190,6 +190,7 @@ public class ReservationService {
             .visitorPhone(request.getVisitorPhone())
             .payment(payment)
             .isCouponUsed(request.getCouponId() != null)
+            .status(ReservationStatus.RESERVED)
             .build());
     }
 

--- a/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/TransactionAspect.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/TransactionAspect.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class TransactionAspect {
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.NESTED)
     public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
         return joinPoint.proceed();
     }


### PR DESCRIPTION
### 💡Motivation
1. 예약 저장 시 status 를 지정하지 않아 db insert 오류 발생
2. 분산 락의 메서드에서 실시간 커밋을 위해 @ Transactional(propagation = Propagation.REQUIRES_NEW)로 설정했었다
하지만 분리된 트랜젝션이기 때문에 create 트랜젝션이 롤백될 경우 함께 롤백이 되지 않는다...

### 📌Changes
-  누락된 필드 추가
-  트랜젝션 수정

### 🫱🏻‍🫲🏻To Reviewers

#### 전파 설명
1. MANDATORY
무조건 부모 트랜잭션에 합류시킨다.부모 트랜잭션이 존재하지 않는다면 예외를 발생시킨다.
2. NESTED 
부모 트랜잭션이 존재하면 부모 트랜잭션에 중첩시키고, 부모 트랜잭션이 존재하지 않는다면 새로운 트랜잭션을 생성한다.
부모 트랜잭션에 예외가 발생하면 자식 트랜잭션도 rollback한다.
자식 트랜잭션에 예외가 발생하더라도 부모 트랜잭션은 rollback하지 않는다. 
이때 롤백은 부모 트랜잭션에서 자식 트랜잭션을 호출하는 지점까지만 롤백된다. 
이후 부모 트랜잭션에서 문제가 없으면 부모 트랜잭션은 끝까지 commit 된다.
현재 트랜잭션이 있으면 중첩 트랜잭션 내에서 실행하고, 그렇지 않으면 REQUIRED 처럼 동작한다.

#### 설정 
트랜젝션 롤백 전파는 부모가 롤백인 경우 모두 롤백하지만, 자식이 롤백인 경우 자식만 롤백을 하게 된다. 
따라서  rollbackFor = NoSuchReservationException.class를 통해 자식에서 해당 에러가 발생하면 함께 롤백되도록 설정한다. 

```java
@Service
public class MyService {

    @Transactional(propagation = Propagation.REQUIRED)
    public void method1() {
        method2();
    }

    @Transactional(propagation = Propagation.MANDATORY, rollbackFor = NoSuchReservationException.class)
    public void method2() {
       method3();
    }

   @Transactional(propagation = Propagation.NESTED)
    public void method3() {
      // NoSuchReservationException 발생 가능성 있음 
    }
}
```

#### 롤백 시나리오 
1. method3에서 NoSuchReservationException이 발생한 경우 (재고 조작 에러)
`
- T3 롤백
- 제어권이 method2()로 돌아옴
- rollbackFor 설정에 따라 method2() 의 T1 롤백
`
2. method1 에러가 발생하여 롤백되는 경우 (재고 조작 이후 예약 생성 과정에서 에러)
`
- T1 롤백
- T3 롤백
`