### PR TITLE
fix: 저장한 객실 이미지를 응답하기 위해 임시로 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -43,6 +43,7 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
             .limit(pageable.getPageSize());
         JPAQuery<Room> countQuery = queryFactory
             .select(room)
+            .from(room)
             .leftJoin(room.accommodation, accommodation).fetchJoin()
             .leftJoin(room.option, roomOption).fetchJoin()
             .leftJoin(room.images, roomImage).fetchJoin()

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
@@ -85,9 +85,10 @@ public class RoomCommandService implements RoomCommandUseCase {
             .option(RoomOptionRequest.toEntity(request.option()))
             .build()
         );
-        roomQueryUseCase.saveRoomImages(RoomImageRequest.toEntity(room, request.images()));
-
-        em.refresh(room);
+        // 저장한 객실 이미지를 응답하기 위한 임시 방편
+        roomQueryUseCase.saveRoomImages(RoomImageRequest.toEntity(room, request.images()))
+            .forEach(roomImage -> room.getImages().add(roomImage));
+//        em.refresh(room);
         return RoomInfoResponse.of(room);
     }
 

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/service/RoomCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/service/RoomCommandServiceTest.java
@@ -204,7 +204,7 @@ public class RoomCommandServiceTest {
             given(roomQueryUseCase.saveRoom(any(Accommodation.class), any(Room.class)))
                 .willReturn(room);
             given(roomQueryUseCase.saveRoomImages(any(List.class))).willReturn(List.of(roomImage));
-            doNothing().when(em).refresh(any(Room.class));
+            //doNothing().when(em).refresh(any(Room.class));
 
             // when
             RoomInfoResponse result = roomCommandService.registerRoom(1L, 1L, roomRegisterRequest);
@@ -442,7 +442,7 @@ public class RoomCommandServiceTest {
             given(roomQueryUseCase.saveRoom(any(Accommodation.class), any(Room.class))).willReturn(
                 room);
             given(roomQueryUseCase.saveRoomImages(any(List.class))).willReturn(List.of(roomImage));
-            doNothing().when(em).refresh(any(Room.class));
+            //doNothing().when(em).refresh(any(Room.class));
 
             // when
             RoomInfoResponse result = roomCommandService.saveRoom(accommodation,


### PR DESCRIPTION
### 💡Motivation
- 객실 이미지를 빈 리스트로 반환하는 문제가 있어 수정이 필요합니다.  

### 📌Changes
- 객실 목록 조회에서 누락된 from 절 추가
- 임시방편으로 직접 entity images에 저장한 이미지 삽입 로직 추가

### 🫱🏻‍🫲🏻To Reviewers
- 기한이 얼마 남지 않고, 간단한 수정사항이므로 테스트 통과 시 Merge하도록 하겠습니다!