### PR TITLE
fix: 객실 목록 조회 시 쿠폰 데이터도 응답하도록 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomPageResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomPageResponse.java
@@ -10,7 +10,7 @@ public record RoomPageResponse(
     int totalPages,
     long totalElements,
     boolean isLast,
-    List<RoomInfoResponse> rooms
+    List<RoomsInfoResponse> rooms
 ) {
 
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomsInfoResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/dto/response/RoomsInfoResponse.java
@@ -1,0 +1,51 @@
+package com.backoffice.upjuyanolja.domain.room.dto.response;
+
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.CouponDetailResponse;
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.PriorityQueue;
+import lombok.Builder;
+
+@Builder
+public record RoomsInfoResponse(
+    long id,
+    String name,
+    int defaultCapacity,
+    int maxCapacity,
+    String checkInTime,
+    String checkOutTime,
+    int basePrice,
+    int discountPrice,
+    int amount,
+    String status,
+    List<RoomImageResponse> images,
+    RoomOptionResponse option,
+    List<CouponDetailResponse> coupons
+) {
+
+    public static RoomsInfoResponse of(Room room, List<CouponDetailResponse> coupons) {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Comparator.comparingInt(i -> i));
+        for (CouponDetailResponse coupon : coupons) {
+            pq.offer(coupon.price());
+        }
+        int discountPrice = pq.isEmpty() ? room.getPrice().getOffWeekDaysMinFee() : pq.poll();
+
+        return RoomsInfoResponse.builder()
+            .id(room.getId())
+            .name(room.getName())
+            .defaultCapacity(room.getDefaultCapacity())
+            .maxCapacity(room.getMaxCapacity())
+            .checkInTime(room.getCheckInTime().format(DateTimeFormatter.ofPattern("HH:mm")))
+            .checkOutTime(room.getCheckOutTime().format(DateTimeFormatter.ofPattern("HH:mm")))
+            .basePrice(room.getPrice().getOffWeekDaysMinFee())
+            .discountPrice(discountPrice)
+            .amount(room.getAmount())
+            .status(room.getStatus().name())
+            .images(RoomImageResponse.of(room.getImages()))
+            .option(RoomOptionResponse.of(room.getOption()))
+            .coupons(coupons)
+            .build();
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
@@ -2,6 +2,10 @@ package com.backoffice.upjuyanolja.domain.room.service;
 
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationQueryUseCase;
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.CouponDetailResponse;
+import com.backoffice.upjuyanolja.domain.coupon.entity.Coupon;
+import com.backoffice.upjuyanolja.domain.coupon.entity.DiscountType;
+import com.backoffice.upjuyanolja.domain.coupon.service.CouponService;
 import com.backoffice.upjuyanolja.domain.member.entity.Member;
 import com.backoffice.upjuyanolja.domain.member.service.MemberGetService;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageAddRequest;
@@ -12,6 +16,7 @@ import com.backoffice.upjuyanolja.domain.room.dto.request.RoomRegisterRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomUpdateRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomsInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.entity.Room;
 import com.backoffice.upjuyanolja.domain.room.entity.RoomImage;
 import com.backoffice.upjuyanolja.domain.room.entity.RoomPrice;
@@ -29,6 +34,7 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -44,6 +50,7 @@ public class RoomCommandService implements RoomCommandUseCase {
     private final RoomQueryUseCase roomQueryUseCase;
     private final AccommodationQueryUseCase accommodationQueryUseCase;
     private final EntityManager em;
+    private final CouponService couponService;
 
     @Override
     public RoomInfoResponse registerRoom(
@@ -98,9 +105,17 @@ public class RoomCommandService implements RoomCommandUseCase {
         Accommodation accommodation = accommodationQueryUseCase
             .getAccommodationById(accommodationId);
         checkOwnership(member, accommodation);
-        List<RoomInfoResponse> rooms = new ArrayList<>();
+        List<RoomsInfoResponse> rooms = new ArrayList<>();
         Page<Room> roomPage = roomQueryUseCase.findAllByAccommodationId(accommodationId, pageable);
-        roomPage.get().forEach(room -> rooms.add(RoomInfoResponse.of(room)));
+        roomPage.get().forEach(room -> {
+            List<CouponDetailResponse> couponDetails = new ArrayList<>();
+            List<Coupon> coupons = couponService.getCouponInRoom(room);
+            couponDetails.addAll(couponService
+                .getSortedCouponResponseInRoom(room, coupons, DiscountType.FLAT));
+            couponDetails.addAll(couponService
+                .getSortedCouponResponseInRoom(room, coupons, DiscountType.RATE));
+            rooms.add(RoomsInfoResponse.of(room, couponDetails));
+        });
         return RoomPageResponse.builder()
             .pageNum(roomPage.getNumber())
             .pageSize(roomPage.getSize())

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
@@ -16,6 +16,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.CouponDetailResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageAddRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageDeleteRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageRequest;
@@ -26,6 +27,7 @@ import com.backoffice.upjuyanolja.domain.room.dto.response.RoomImageResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomOptionResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomsInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
 import com.backoffice.upjuyanolja.global.util.RestDocsSupport;
@@ -212,14 +214,15 @@ public class RoomControllerDocsTest extends RestDocsSupport {
     @WithMockUser(roles = "ADMIN")
     void getRooms() throws Exception {
         // given
-        RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+        RoomsInfoResponse roomsInfoResponse = RoomsInfoResponse.builder()
             .id(1L)
             .name("65m² 킹룸")
             .defaultCapacity(2)
             .maxCapacity(3)
             .checkInTime("15:00")
             .checkOutTime("11:00")
-            .price(100000)
+            .basePrice(100000)
+            .discountPrice(80000)
             .amount(858)
             .status("SELLING")
             .option(RoomOptionResponse.builder()
@@ -231,6 +234,23 @@ public class RoomControllerDocsTest extends RestDocsSupport {
                 .id(1L)
                 .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
                 .build()))
+            .coupons(List.of(
+                CouponDetailResponse.builder()
+                    .id(2L)
+                    .name("20% 할인")
+                    .price(80000)
+                    .build(),
+                CouponDetailResponse.builder()
+                    .id(3L)
+                    .name("15000원 할인")
+                    .price(85000)
+                    .build(),
+                CouponDetailResponse.builder()
+                    .id(1L)
+                    .name("10000원 할인")
+                    .price(90000)
+                    .build()
+            ))
             .build();
 
         RoomPageResponse roomPageResponse = RoomPageResponse.builder()
@@ -239,7 +259,7 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .totalPages(1)
             .totalElements(1)
             .isLast(true)
-            .rooms(List.of(roomInfoResponse))
+            .rooms(List.of(roomsInfoResponse))
             .build();
 
         given(securityUtil.getCurrentMemberId()).willReturn(1L);
@@ -284,8 +304,10 @@ public class RoomControllerDocsTest extends RestDocsSupport {
                         .description("객실 체크인 시간"),
                     fieldWithPath("rooms[].checkOutTime").type(JsonFieldType.STRING)
                         .description("객실 체크아웃 시간"),
-                    fieldWithPath("rooms[].price").type(JsonFieldType.NUMBER)
+                    fieldWithPath("rooms[].basePrice").type(JsonFieldType.NUMBER)
                         .description("객실 가격"),
+                    fieldWithPath("rooms[].discountPrice").type(JsonFieldType.NUMBER)
+                        .description("쿠폰 할인 가격 중 가장 저렴한 객실 가격"),
                     fieldWithPath("rooms[].amount").type(JsonFieldType.NUMBER)
                         .description("객실 개수"),
                     fieldWithPath("rooms[].status").type(JsonFieldType.STRING)
@@ -296,6 +318,14 @@ public class RoomControllerDocsTest extends RestDocsSupport {
                         .description("객실 이미지 식별자"),
                     fieldWithPath("rooms[].images[].url").type(JsonFieldType.STRING)
                         .description("객실 이미지 URL"),
+                    fieldWithPath("rooms[].coupons").type(JsonFieldType.ARRAY)
+                        .description("쿠폰 배열"),
+                    fieldWithPath("rooms[].coupons[].id").type(JsonFieldType.NUMBER)
+                        .description("쿠폰 식별자").optional(),
+                    fieldWithPath("rooms[].coupons[].name").type(JsonFieldType.STRING)
+                        .description("쿠폰 이름").optional(),
+                    fieldWithPath("rooms[].coupons[].price").type(JsonFieldType.NUMBER)
+                        .description("쿠폰을 적용한 객실 가격").optional(),
                     fieldWithPath("rooms[].option").type(JsonFieldType.OBJECT)
                         .description("객실 옵션"),
                     fieldWithPath("rooms[].option.airCondition").type(

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.CouponDetailResponse;
 import com.backoffice.upjuyanolja.domain.room.controller.RoomController;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageAddRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageDeleteRequest;
@@ -23,6 +24,7 @@ import com.backoffice.upjuyanolja.domain.room.dto.response.RoomImageResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomOptionResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomPageResponse;
+import com.backoffice.upjuyanolja.domain.room.dto.response.RoomsInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import com.backoffice.upjuyanolja.global.security.AuthenticationConfig;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
@@ -151,14 +153,15 @@ public class RoomControllerTest {
         @DisplayName("객실 목록을 조회할 수 있다.")
         void _willSuccess() throws Exception {
             // given
-            RoomInfoResponse roomInfoResponse = RoomInfoResponse.builder()
+            RoomsInfoResponse roomsInfoResponse = RoomsInfoResponse.builder()
                 .id(1L)
                 .name("65m² 킹룸")
                 .defaultCapacity(2)
                 .maxCapacity(3)
                 .checkInTime("15:00")
                 .checkOutTime("11:00")
-                .price(100000)
+                .basePrice(100000)
+                .discountPrice(80000)
                 .amount(858)
                 .status("SELLING")
                 .option(RoomOptionResponse.builder()
@@ -170,6 +173,23 @@ public class RoomControllerTest {
                     .id(1L)
                     .url("http://tong.visitkorea.or.kr/cms/resource/77/2876777_image2_1.jpg")
                     .build()))
+                .coupons(List.of(
+                    CouponDetailResponse.builder()
+                        .id(2L)
+                        .name("20% 할인")
+                        .price(80000)
+                        .build(),
+                    CouponDetailResponse.builder()
+                        .id(3L)
+                        .name("15000원 할인")
+                        .price(85000)
+                        .build(),
+                    CouponDetailResponse.builder()
+                        .id(1L)
+                        .name("10000원 할인")
+                        .price(90000)
+                        .build()
+                ))
                 .build();
 
             RoomPageResponse roomPageResponse = RoomPageResponse.builder()
@@ -178,7 +198,7 @@ public class RoomControllerTest {
                 .totalPages(1)
                 .totalElements(1)
                 .isLast(true)
-                .rooms(List.of(roomInfoResponse))
+                .rooms(List.of(roomsInfoResponse))
                 .build();
 
             given(securityUtil.getCurrentMemberId()).willReturn(1L);
@@ -203,7 +223,8 @@ public class RoomControllerTest {
                 .andExpect(jsonPath("$.rooms[0].maxCapacity").isNumber())
                 .andExpect(jsonPath("$.rooms[0].checkInTime").isString())
                 .andExpect(jsonPath("$.rooms[0].checkOutTime").isString())
-                .andExpect(jsonPath("$.rooms[0].price").isNumber())
+                .andExpect(jsonPath("$.rooms[0].basePrice").isNumber())
+                .andExpect(jsonPath("$.rooms[0].discountPrice").isNumber())
                 .andExpect(jsonPath("$.rooms[0].amount").isNumber())
                 .andExpect(jsonPath("$.rooms[0].status").isString())
                 .andExpect(jsonPath("$.rooms[0].images").isArray())
@@ -213,6 +234,10 @@ public class RoomControllerTest {
                 .andExpect(jsonPath("$.rooms[0].option.airCondition").isBoolean())
                 .andExpect(jsonPath("$.rooms[0].option.tv").isBoolean())
                 .andExpect(jsonPath("$.rooms[0].option.internet").isBoolean())
+                .andExpect(jsonPath("$.rooms[0].coupons").isArray())
+                .andExpect(jsonPath("$.rooms[0].coupons[0].id").isNumber())
+                .andExpect(jsonPath("$.rooms[0].coupons[0].name").isString())
+                .andExpect(jsonPath("$.rooms[0].coupons[0].price").isNumber())
                 .andDo(print());
 
             verify(roomCommandUseCase, times(1))


### PR DESCRIPTION
### 💡Motivation
- 객실 목록 조회 시 쿠폰 데이터도 응답하도록 수정해야 합니다. 

### 📌Changes
- 쿠폰 관련 데이터도 함께 반환하도록 수정

### 🫱🏻‍🫲🏻To Reviewers
- 빠르게 반영되어야 하는 중요한 수정 사항입니다!