### PR TITLE
 fix: Transaction 롤백 에러 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
@@ -55,7 +55,7 @@ public class ReservationService {
     private final RoomCommandUseCase roomCommandUseCase;
     private final ReservationStockService stockService;
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void create(Member currentMember, CreateReservationRequest request) {
         Coupon coupon = null;
 
@@ -107,8 +107,7 @@ public class ReservationService {
         }
     }
 
-    @Transactional(propagation = Propagation.MANDATORY, rollbackFor = InvalidReservationInfoException.class)
-    public void decreaseRoomStock(Room room, LocalDate startDate, LocalDate endDate) {
+    private void decreaseRoomStock(Room room, LocalDate startDate, LocalDate endDate) {
         // 객실 재고 검증 및 get
         List<RoomStock> roomStocks = getRoomStock(room, startDate, endDate);
 
@@ -135,8 +134,7 @@ public class ReservationService {
         return modifiableRoomStocks;
     }
 
-    @Transactional(propagation = Propagation.MANDATORY, rollbackFor = InvalidCouponException.class)
-    public Coupon decreaseCouponStock(Coupon coupon) {
+    private Coupon decreaseCouponStock(Coupon coupon) {
         if (coupon.getStock() < 1) {
             throw new InvalidCouponException();
         }
@@ -197,7 +195,7 @@ public class ReservationService {
             .build());
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cancel(Member currentMember, Long reservationId) {
         Reservation reservation = reservationRepository.findByIdAndMember(reservationId,
                 currentMember)
@@ -223,8 +221,7 @@ public class ReservationService {
         reservationRepository.save(reservation);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY, rollbackFor = NoSuchReservationException.class)
-    public void increaseCouponStock(Reservation reservation) {
+    private void increaseCouponStock(Reservation reservation) {
         CouponRedeem couponRedeem = couponRedeemRepository.findByReservation(reservation)
             .orElseThrow(NoSuchReservationException::new);
 
@@ -234,8 +231,7 @@ public class ReservationService {
         couponRedeemRepository.delete(couponRedeem);
     }
 
-    @Transactional(propagation = Propagation.MANDATORY, rollbackFor = NoSuchReservationException.class)
-    public void increaseRoomStock(ReservationRoom reservationRoom) {
+    private void increaseRoomStock(ReservationRoom reservationRoom) {
         int daysCount =
             Period.between(reservationRoom.getStartDate(), reservationRoom.getEndDate()).getDays()
                 + 1;

--- a/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/TransactionAspect.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/TransactionAspect.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 public class TransactionAspect {
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW, rollbackFor = RuntimeException.class)
     public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
         return joinPoint.proceed();
     }


### PR DESCRIPTION
### 💡Motivation
로컬 서버에서는 롤백이 제대로 되지만 
배포된 서버에서는 롤백이 제대로 작동하지 않아
트랜젝션, 롤백 관련 설정 수정해봤습니다...

### 📌Changes
1. 예약 서비스 트렌젝션 자체를 새 트랜젝션으로 실행되도록 설정
2. 재고 수정하는 트렌젝션 자체에 RunTimeException이 발생하면 rollback 하도록 조건 추가 

### 🫱🏻‍🫲🏻To Reviewers
계속해서 트랜젝션 제어가 제대로 안되면 
동시성제어를 새 트랜젝션이 아닌 기존 트랜젝션에서 수행하도록 변경해야 할듯 합니다...
또는 재고 수정을 예약 생성 후 맨 마지막에 수행...