### PR TITLE
feat: 객실 재고 생성 스케줄러 구현

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomCommandService.java
@@ -34,7 +34,6 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -96,6 +95,9 @@ public class RoomCommandService implements RoomCommandUseCase {
         roomQueryUseCase.saveRoomImages(RoomImageRequest.toEntity(room, request.images()))
             .forEach(roomImage -> room.getImages().add(roomImage));
 //        em.refresh(room);
+
+        createRoomStock(room);
+
         return RoomInfoResponse.of(room);
     }
 
@@ -226,6 +228,16 @@ public class RoomCommandService implements RoomCommandUseCase {
         }
         if (!flag) {
             throw new InvalidRoomStatusException();
+        }
+    }
+
+    private void createRoomStock(Room room) {
+        for (int i = 0; i < 30; i++) {
+            roomQueryUseCase.saveRoomStock(RoomStock.builder()
+                .room(room)
+                .count(room.getAmount())
+                .date(LocalDate.now().plusDays(i))
+                .build());
         }
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/RoomQueryService.java
@@ -75,6 +75,11 @@ public class RoomQueryService implements RoomQueryUseCase {
     }
 
     @Override
+    public void saveRoomStock(RoomStock roomStock) {
+        roomStockRepository.save(roomStock);
+    }
+
+    @Override
     public List<RoomStock> findStockByRoom(Room room) {
         return roomStockRepository.findByRoom(room)
             .orElseThrow(RoomStockNotFoundException::new);

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomQueryUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/service/usecase/RoomQueryUseCase.java
@@ -31,6 +31,8 @@ public interface RoomQueryUseCase {
 
     void deleteRoomImages(List<RoomImage> requests);
 
+    void saveRoomStock(RoomStock roomStock);
+
     List<RoomStock> findStockByRoom(Room room);
 
     List<RoomStock> findStocksByRoomAndDateAfter(Room room, LocalDate date);

--- a/src/main/java/com/backoffice/upjuyanolja/global/scheduler/RoomStockScheduler.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/scheduler/RoomStockScheduler.java
@@ -1,0 +1,31 @@
+package com.backoffice.upjuyanolja.global.scheduler;
+
+import com.backoffice.upjuyanolja.domain.room.entity.Room;
+import com.backoffice.upjuyanolja.domain.room.entity.RoomStock;
+import com.backoffice.upjuyanolja.domain.room.repository.RoomRepository;
+import com.backoffice.upjuyanolja.domain.room.repository.RoomStockRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@EnableScheduling
+@RequiredArgsConstructor
+public class RoomStockScheduler {
+
+    private final RoomRepository roomRepository;
+    private final RoomStockRepository roomStockRepository;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    private void addStockAfter30Days() {
+        List<Room> rooms = roomRepository.findAll();
+        for (Room room : rooms) {
+            roomStockRepository.save(RoomStock.builder()
+                .room(room)
+                .count(room.getAmount())
+                .date(LocalDate.now().plusDays(29))
+                .build());
+        }
+    }
+}


### PR DESCRIPTION
### 💡Motivation
- 객실 등록 시 객실은 당일 포함 30일 치 재고가 생성됩니다. 
- 매일 새벽 3시에 29일 뒤의 재고를 생성해야 합니다. 
- 따라서 매일 새벽 3시에 객실 재고를 생성 하는 스케줄러를 구현해야 합니다. 
- 객실 등록 시 객실 재고 생성 로직이 누락되어 있는 걸 확인했고, 해당 로직도 추가했습니다!

### 📌Changes
- 객실 등록 시 객실 재고 생성 로직 추가
- 객실 재고 생성 스케줄러 구현

### 🫱🏻‍🫲🏻To Reviewers
- 리뷰 부탁 드립니다!! 😊

closes #122 