### PR TITLE
refactor: 재고 조작을 가장 마지막에 하도록 리팩토링

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/ConcurrencyAspect.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/concurrency/aspect/ConcurrencyAspect.java
@@ -43,6 +43,8 @@ public class ConcurrencyAspect {
                 throw new IllegalArgumentException();
             }
 
+            log.info("Redisson GetLock {}", lockName);
+
             // Proceed with the original method execution
             return transactionAspect.proceed(joinPoint);
         } finally {


### PR DESCRIPTION
### 💡Motivation
- 재고 조작 이후 예약 생성 로직에서 예외 발생 시 재고 롤백이 되지 않습니다. 

### 📌Changes
- 재고 감소 ->예약 생성을 수행하는 순서를 예약 생성 ->재고 감소를 하도록 수정했습니다. 

### 🫱🏻‍🫲🏻To Reviewers
REQUIRES_NEW 트랜젝션에서  exception이 터졌을 때, 처리를 하지 않으면 전파되어 호출 트랜젝션도 함께 롤백이 됩니다. 
따라서 예약 생성 후 재고 감소에서 예외가 발생하면 재고감소, 예약 생성 모두 롤백이 가능합니다. 
하지만 호출 트랜젝션에서 예외 발생 시 재고 트랜젝션은 롤백될 수 없습니다.

롤백 제어가 가능한 작업들은 가장 먼저 수행하고 재고 관련 트랜젝션을 가장 하위에 두어
재고 조작에서 예외가 발생하면 예외 전파에 의한 롤백이 가능하도록 수정한다면 
예약생성-재고 감소 사이의 롤백은 제어가 가능합니다. 

하지만 전체 로직 모두 롤백 제어가 된 것 은 아니라서 추후 개선이 필요합니다.
그 이유는 아래에 롤백 시나리오를 봐주시면 이해가 되실 것 같습니다.
1. 예약 생성 -> exception
- 예약 롤백

2. 예약 생성 -> 쿠폰 재고 감소 -> exception
 - 예약 롤백
 - 쿠폰 재고 롤백
 
3. 예약 생성 -> 쿠폰 재고 감소 -> 숙소 재고 감소 -> exception
- 예약 롤백
- 쿠폰 재고 롤백 X 
- exception 터진 숙소 재고만 롤백 
(숙소 재고가 날짜별로 있어 각 날짜마다 REQUIRES_NEW. 따라서 예외가 발생한 해당 날짜의 재고만 롤백 가능)

즉, 재고 감소 도중 에러 발생 시 예약과 해당 재고(쿠폰 or 객실)에 대해서만 롤백이 가능합니다 
하지만 재고 감소의 경우 동시성 제어를 해두었기 때문에 서버 내부 에러가 아니라면 실패할 가능성이 적습니다..!

이러한 이유로 임시방편으로나마 롤백 처리가 되도록 해놨습니다 ~! 

> [[Spring] Transactional REQUIRES_NEW 옵션에서의 Rollback](https://devoong2.tistory.com/entry/Spring-Transactional-REQUIRESNEW-%EC%98%B5%EC%85%98%EC%97%90%EC%84%9C%EC%9D%98-Rollback?category=1078053)
> [응? 이게 왜 롤백되는거지?](https://techblog.woowahan.com/2606/)