### PR TITLE
refactor: 포인트 충전 내역 조회 dto 변경

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/dto/response/PointChargeDetailResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/dto/response/PointChargeDetailResponse.java
@@ -13,13 +13,13 @@ public record PointChargeDetailResponse(
     String name,
     long trade,
     long amount,
-    List<PointChargeReceiptResponse> receipt
+    PointChargeReceiptResponse receipt
 
 ) {
 
     public static PointChargeDetailResponse of(
         PointCharges pointCharges, String category, String type,
-        List<PointChargeReceiptResponse> receipt
+        PointChargeReceiptResponse receipt
     ) {
         return PointChargeDetailResponse.builder()
             .id(pointCharges.getId())

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/repository/PointUsageRepository.java
@@ -1,12 +1,9 @@
 package com.backoffice.upjuyanolja.domain.point.repository;
 
-import com.backoffice.upjuyanolja.domain.point.entity.PointCharges;
 import com.backoffice.upjuyanolja.domain.point.entity.PointUsage;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PointUsageRepository extends JpaRepository<PointUsage, Long>,
     PointUsageCustomRepository {
 
-    List<PointUsage> findByPointCharges(PointCharges pointCharges);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/point/service/PointService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/point/service/PointService.java
@@ -164,34 +164,26 @@ public class PointService {
 
     }
 
-    private List<PointChargeReceiptResponse> getPointChargeReceiptResponse(
+    private PointChargeReceiptResponse getPointChargeReceiptResponse(
         PointCharges pointCharges) {
 
         switch (pointCharges.getPointStatus()) {
-            case PAID:
-                return Collections.singletonList(PointChargeReceiptResponse.of(
+            case PAID :
+            case USED :
+                return PointChargeReceiptResponse.of(
                     pointCharges.getOrderName(),
                     pointCharges.getChargeDate().toString(),
                     pointCharges.getChargePoint()
-                ));
+                );
             case CANCELED:
-                PointRefunds pointRefund = pointRefundsRepository.findByPointCharges(
-                    pointCharges);
-                return Collections.singletonList(PointChargeReceiptResponse.of(
+                PointRefunds pointRefund = pointRefundsRepository.findByPointCharges(pointCharges);
+                return PointChargeReceiptResponse.of(
                     pointCharges.getOrderName(),
                     pointRefund.getRefundDate().toString(),
                     pointCharges.getChargePoint()
-                ));
-            case USED:
-                return pointUsageRepository.findByPointCharges(pointCharges).stream()
-                    .map(pointUsage -> PointChargeReceiptResponse.of(
-                        pointUsage.getOrderName(),
-                        pointUsage.getOrderDate().toString(),
-                        pointUsage.getOrderPrice()
-                    ))
-                    .toList();
+                );
             default:
-                return Collections.emptyList();
+                return PointChargeReceiptResponse.builder().build();
         }
 
     }


### PR DESCRIPTION
### 💡Motivation
- 영수증 배열이 아닌 영수증 객체 하나만 보내면 됐습니다
- 포인트 사용과 포인트 결제 완료는 같은 영수증 값을 가집니다(포인트 충전 정보)
- 포인트 환불만 환불 할 때의 정보로 다른 값을 가집니다

### 📌Changes
<img width="290" alt="image" src="https://github.com/Upjuyanolja/Upjuyanolja_BE/assets/52107658/9c6e4ede-a66e-4916-bdea-7ec2cbf9b1fe">

issue: #108