### PR TITLE
refactor: 숙소, 객실 API URI 수정

### DIFF
--- a/src/docs/asciidoc/accommodation/accommodation-api.adoc
+++ b/src/docs/asciidoc/accommodation/accommodation-api.adoc
@@ -16,13 +16,13 @@ endif::[]
 
 === HttpRequest
 
-include::{snippets}/accommodation-controller-docs-test/register-accommodation/http-request.adoc[]
-include::{snippets}/accommodation-controller-docs-test/register-accommodation/request-fields.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/register-accommodation/http-request.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/register-accommodation/request-fields.adoc[]
 
 === HttpResponse
 
-include::{snippets}/accommodation-controller-docs-test/register-accommodation/http-response.adoc[]
-include::{snippets}/accommodation-controller-docs-test/register-accommodation/response-fields.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/register-accommodation/http-response.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/register-accommodation/response-fields.adoc[]
 
 [[Get-Accommodation-Ownership]]
 == 보유 숙소 목록 조회
@@ -31,27 +31,9 @@ include::{snippets}/accommodation-controller-docs-test/register-accommodation/re
 
 === HttpRequest
 
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/http-request.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/get-accommodation-ownership/http-request.adoc[]
 
 === HttpResponse
 
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/http-response.adoc[]
-include::{snippets}/accommodation-controller-docs-test/get-accommodation-ownership/response-fields.adoc[]
-
-[[Save-Images]]
-== 이미지 저장
-
-이미지 저장 API 입니다.
-이미지를 저장하고 URL을 반환합니다.
-
-=== HttpRequest
-
-Http Request 가 이미지로 인해 길어져, Httpie Request 로 문서화했습니다.
-
-include::{snippets}/accommodation-controller-docs-test/save-images/httpie-request.adoc[]
-include::{snippets}/accommodation-controller-docs-test/save-images/request-parts.adoc[]
-
-=== HttpResponse
-
-include::{snippets}/accommodation-controller-docs-test/save-images/http-response.adoc[]
-include::{snippets}/accommodation-controller-docs-test/save-images/response-fields.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/get-accommodation-ownership/http-response.adoc[]
+include::{snippets}/accommodation-backoffice-controller-docs-test/get-accommodation-ownership/response-fields.adoc[]

--- a/src/docs/asciidoc/image/image-api.adoc
+++ b/src/docs/asciidoc/image/image-api.adoc
@@ -1,0 +1,28 @@
+ifndef::snippets[]
+:snippets: build/generated-snippets
+endif::[]
+
+= Image REST API Docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+[[Save-Images]]
+== 이미지 저장
+
+이미지 저장 API 입니다.
+이미지를 저장하고 URL을 반환합니다.
+
+=== HttpRequest
+
+Http Request 가 이미지로 인해 길어져, Httpie Request 로 문서화했습니다.
+
+include::{snippets}/image-controller-docs-test/save-images/httpie-request.adoc[]
+include::{snippets}/image-controller-docs-test/save-images/request-parts.adoc[]
+
+=== HttpResponse
+
+include::{snippets}/image-controller-docs-test/save-images/http-response.adoc[]
+include::{snippets}/image-controller-docs-test/save-images/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -19,6 +19,8 @@
 
 === link:coupon/coupon-api.html[쿠폰 API, window=blank]
 
+=== link:image/image-api.html[이미지 API, window=blank]
+
 == API Common Response
 
 [[overview-status-code]]

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationBackofficeController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationBackofficeController.java
@@ -1,0 +1,62 @@
+package com.backoffice.upjuyanolja.domain.accommodation.controller;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationDetailResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationPageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationCommandUseCase;
+import com.backoffice.upjuyanolja.global.security.SecurityUtil;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/backoffice-api/accommodations")
+@RequiredArgsConstructor
+@Validated
+public class AccommodationBackofficeController {
+
+    private final AccommodationCommandUseCase accommodationCommandUseCase;
+    private final SecurityUtil securityUtil;
+
+    @PostMapping
+    public ResponseEntity<AccommodationInfoResponse> registerAccommodation(
+        @Valid @RequestBody AccommodationRegisterRequest accommodationRegisterRequest
+    ) {
+        log.info("POST /backoffice-api/accommodations");
+
+        AccommodationInfoResponse response = accommodationCommandUseCase
+            .createAccommodation(securityUtil.getCurrentMemberId(), accommodationRegisterRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<AccommodationOwnershipResponse> getAccommodationOwnership() {
+        log.info("GET /backoffice-api/accommodations");
+
+        AccommodationOwnershipResponse response = accommodationCommandUseCase
+            .getAccommodationOwnership(securityUtil.getCurrentMemberId());
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/AccommodationController.java
@@ -1,16 +1,10 @@
 package com.backoffice.upjuyanolja.domain.accommodation.controller;
 
-import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationDetailResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationPageResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationCommandUseCase;
-import com.backoffice.upjuyanolja.global.security.SecurityUtil;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.validator.constraints.Length;
@@ -23,12 +17,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -38,18 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class AccommodationController {
 
     private final AccommodationCommandUseCase accommodationCommandUseCase;
-    private final SecurityUtil securityUtil;
-
-    @PostMapping
-    public ResponseEntity<AccommodationInfoResponse> registerAccommodation(
-        @Valid @RequestBody AccommodationRegisterRequest accommodationRegisterRequest
-    ) {
-        log.info("POST /api/accommodations");
-
-        AccommodationInfoResponse response = accommodationCommandUseCase
-            .createAccommodation(securityUtil.getCurrentMemberId(), accommodationRegisterRequest);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
 
     @GetMapping
     public ResponseEntity<AccommodationPageResponse> getAccommodations(
@@ -83,29 +62,5 @@ public class AccommodationController {
         AccommodationDetailResponse response = accommodationCommandUseCase
             .findAccommodationWithRooms(accommodationId, startDate, endDate);
         return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @GetMapping("/backoffice")
-    public ResponseEntity<AccommodationOwnershipResponse> getAccommodationOwnership() {
-        log.info("GET /api/accommodations/backoffice");
-
-        AccommodationOwnershipResponse response = accommodationCommandUseCase
-            .getAccommodationOwnership(securityUtil.getCurrentMemberId());
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
-
-    @PostMapping("/images")
-    public ResponseEntity<ImageResponse> saveImages(
-        @RequestParam(value = "image1") MultipartFile imageFile1,
-        @RequestParam(value = "image2") MultipartFile imageFile2,
-        @RequestParam(value = "image3") MultipartFile imageFile3,
-        @RequestParam(value = "image4") MultipartFile imageFile4,
-        @RequestParam(value = "image5") MultipartFile imageFile5
-    ) {
-        log.info("GET /api/accommodations/urls");
-
-        ImageResponse response = accommodationCommandUseCase
-            .saveImages(List.of(imageFile1, imageFile2, imageFile3, imageFile4, imageFile5));
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/ImageController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/controller/ImageController.java
@@ -1,0 +1,45 @@
+package com.backoffice.upjuyanolja.domain.accommodation.controller;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.ImageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping("/backoffice-api/images")
+@RequiredArgsConstructor
+@Validated
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ResponseEntity<ImageResponse> saveImages(
+        @RequestParam(value = "image1") MultipartFile imageFile1,
+        @RequestParam(value = "image2") MultipartFile imageFile2,
+        @RequestParam(value = "image3") MultipartFile imageFile3,
+        @RequestParam(value = "image4") MultipartFile imageFile4,
+        @RequestParam(value = "image5") MultipartFile imageFile5
+    ) {
+        log.info("POST /backoffice-api/images");
+
+        ImageResponse response = imageService.saveImages(List.of(
+            imageFile1,
+            imageFile2,
+            imageFile3,
+            imageFile4,
+            imageFile5)
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationCommandService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/AccommodationCommandService.java
@@ -8,8 +8,6 @@ import com.backoffice.upjuyanolja.domain.accommodation.dto.response.Accommodatio
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationPageResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationSummaryResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageUrlResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwnership;
@@ -17,7 +15,6 @@ import com.backoffice.upjuyanolja.domain.accommodation.entity.Address;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Category;
 import com.backoffice.upjuyanolja.domain.accommodation.exception.AccommodationImageNotExistsException;
 import com.backoffice.upjuyanolja.domain.accommodation.exception.AccommodationNotFoundException;
-import com.backoffice.upjuyanolja.domain.accommodation.exception.FailedSaveImageException;
 import com.backoffice.upjuyanolja.domain.accommodation.repository.AccommodationRepository;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationCommandUseCase;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationQueryUseCase;
@@ -35,7 +32,6 @@ import com.backoffice.upjuyanolja.domain.room.exception.RoomNotExistsException;
 import com.backoffice.upjuyanolja.domain.room.service.RoomQueryService;
 import com.backoffice.upjuyanolja.domain.room.service.usecase.RoomCommandUseCase;
 import jakarta.persistence.EntityManager;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -48,7 +44,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional
@@ -125,31 +120,6 @@ public class AccommodationCommandService implements AccommodationCommandUseCase 
             AccommodationNameResponse.of(ownership.getAccommodation())));
         return AccommodationOwnershipResponse.builder()
             .accommodations(accommodations)
-            .build();
-    }
-
-    @Override
-    public ImageResponse saveImages(List<MultipartFile> imageMultipartFiles) {
-        List<ImageUrlResponse> imageUrls = new ArrayList<>();
-
-        for (MultipartFile multipartFile : imageMultipartFiles) {
-            try {
-                if (multipartFile.isEmpty()) {
-                    imageUrls.add(ImageUrlResponse.builder()
-                        .url(null)
-                        .build());
-                } else {
-                    imageUrls.add(ImageUrlResponse.builder()
-                        .url(s3UploadService.saveFile(multipartFile))
-                        .build());
-                }
-            } catch (IOException e) {
-                throw new FailedSaveImageException();
-            }
-        }
-
-        return ImageResponse.builder()
-            .urls(imageUrls)
             .build();
     }
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/ImageService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/ImageService.java
@@ -1,0 +1,44 @@
+package com.backoffice.upjuyanolja.domain.accommodation.service;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageUrlResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.exception.FailedSaveImageException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3UploadService s3UploadService;
+
+    public ImageResponse saveImages(List<MultipartFile> imageMultipartFiles) {
+        List<ImageUrlResponse> imageUrls = new ArrayList<>();
+
+        for (MultipartFile multipartFile : imageMultipartFiles) {
+            try {
+                if (multipartFile.isEmpty()) {
+                    imageUrls.add(ImageUrlResponse.builder()
+                        .url(null)
+                        .build());
+                } else {
+                    imageUrls.add(ImageUrlResponse.builder()
+                        .url(s3UploadService.saveFile(multipartFile))
+                        .build());
+                }
+            } catch (IOException e) {
+                throw new FailedSaveImageException();
+            }
+        }
+
+        return ImageResponse.builder()
+            .urls(imageUrls)
+            .build();
+    }
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/accommodation/service/usecase/AccommodationCommandUseCase.java
@@ -32,6 +32,4 @@ public interface AccommodationCommandUseCase {
     );
 
     AccommodationOwnershipResponse getAccommodationOwnership(long memberId);
-
-    ImageResponse saveImages(List<MultipartFile> imageMultipartFiles);
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
@@ -51,7 +51,12 @@ public class RoomController {
         @RequestParam(defaultValue = "0") int pageNum,
         @RequestParam(defaultValue = "10") int pageSize
     ) {
-        log.info("GET /backoffice-api/accommodations/{}/rooms", accommodationId);
+        log.info(
+            "GET /backoffice-api/accommodations/{}/rooms?pageNum={}&pageSize={}",
+            accommodationId,
+            pageNum,
+            pageSize
+        );
 
         RoomPageResponse response = roomCommandUseCase.getRooms(
             securityUtil.getCurrentMemberId(),

--- a/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/room/controller/RoomController.java
@@ -23,19 +23,19 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/rooms")
+@RequestMapping("/backoffice-api/accommodations/{accommodationId}/rooms")
 @RequiredArgsConstructor
 public class RoomController {
 
     private final RoomCommandUseCase roomCommandUseCase;
     private final SecurityUtil securityUtil;
 
-    @PostMapping("/{accommodationId}")
+    @PostMapping
     public ResponseEntity<RoomInfoResponse> registerRoom(
         @PathVariable long accommodationId,
         @RequestBody RoomRegisterRequest roomRegisterRequest
     ) {
-        log.info("POST /api/rooms/{}", accommodationId);
+        log.info("POST /backoffice-api/accommodations/{}/rooms", accommodationId);
 
         RoomInfoResponse response = roomCommandUseCase.registerRoom(
             securityUtil.getCurrentMemberId(),
@@ -45,13 +45,13 @@ public class RoomController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @GetMapping("/list/{accommodationId}")
+    @GetMapping
     public ResponseEntity<RoomPageResponse> getRooms(
         @PathVariable long accommodationId,
         @RequestParam(defaultValue = "0") int pageNum,
         @RequestParam(defaultValue = "10") int pageSize
     ) {
-        log.info("GET /api/rooms/list/{}", accommodationId);
+        log.info("GET /backoffice-api/accommodations/{}/rooms", accommodationId);
 
         RoomPageResponse response = roomCommandUseCase.getRooms(
             securityUtil.getCurrentMemberId(),
@@ -65,8 +65,11 @@ public class RoomController {
     }
 
     @GetMapping("/{roomId}")
-    public ResponseEntity<RoomInfoResponse> getRoom(@PathVariable long roomId) {
-        log.info("GET /api/rooms/{}", roomId);
+    public ResponseEntity<RoomInfoResponse> getRoom(
+        @PathVariable long accommodationId,
+        @PathVariable long roomId
+    ) {
+        log.info("GET /backoffice-api/accommodations/{}/rooms/{}", accommodationId, roomId);
 
         RoomInfoResponse response = roomCommandUseCase
             .getRoom(securityUtil.getCurrentMemberId(), roomId);
@@ -75,10 +78,11 @@ public class RoomController {
 
     @PutMapping("/{roomId}")
     public ResponseEntity<RoomInfoResponse> modifyRoom(
+        @PathVariable long accommodationId,
         @PathVariable long roomId,
         @RequestBody RoomUpdateRequest roomUpdateRequest
     ) {
-        log.info("PUT /api/rooms/{}", roomId);
+        log.info("PUT /backoffice-api/accommodations/{}/rooms/{}", accommodationId, roomId);
 
         RoomInfoResponse response = roomCommandUseCase
             .modifyRoom(securityUtil.getCurrentMemberId(), roomId, roomUpdateRequest);
@@ -86,8 +90,11 @@ public class RoomController {
     }
 
     @DeleteMapping("/{roomId}")
-    public ResponseEntity<RoomInfoResponse> deleteRoom(@PathVariable long roomId) {
-        log.info("DELETE /api/rooms/{}", roomId);
+    public ResponseEntity<RoomInfoResponse> deleteRoom(
+        @PathVariable long accommodationId,
+        @PathVariable long roomId
+    ) {
+        log.info("DELETE /backoffice-api/accommodations/{}/rooms/{}", accommodationId, roomId);
 
         RoomInfoResponse response = roomCommandUseCase
             .deleteRoom(securityUtil.getCurrentMemberId(), roomId);

--- a/src/main/java/com/backoffice/upjuyanolja/global/security/AuthenticationConfig.java
+++ b/src/main/java/com/backoffice/upjuyanolja/global/security/AuthenticationConfig.java
@@ -33,10 +33,9 @@ public class AuthenticationConfig {
         "/api/open-api"
     };
     private static final String[] PERMIT_OWNER_URL_ARRAY = {
-        "/api/accommodations/backoffice/**",
+        "/backoffice-api/**",
         "/api/coupons/backoffice/**",
         "/api/points/**",
-        "/api/rooms/**"
     };
 
     @Bean

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationBackofficeControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/AccommodationBackofficeControllerDocsTest.java
@@ -5,13 +5,10 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationImageRequest;
@@ -22,8 +19,6 @@ import com.backoffice.upjuyanolja.domain.accommodation.dto.response.Accommodatio
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationNameResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOptionResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageUrlResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.service.AccommodationCommandService;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomImageRequest;
 import com.backoffice.upjuyanolja.domain.room.dto.request.RoomOptionRequest;
@@ -33,21 +28,18 @@ import com.backoffice.upjuyanolja.domain.room.dto.response.RoomInfoResponse;
 import com.backoffice.upjuyanolja.domain.room.dto.response.RoomOptionResponse;
 import com.backoffice.upjuyanolja.global.security.SecurityUtil;
 import com.backoffice.upjuyanolja.global.util.RestDocsSupport;
-import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
-public class AccommodationControllerDocsTest extends RestDocsSupport {
+public class AccommodationBackofficeControllerDocsTest extends RestDocsSupport {
 
     @MockBean
     private AccommodationCommandService accommodationCommandService;
@@ -164,7 +156,7 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
             .willReturn(accommodationInfoResponse);
 
         // when then
-        mockMvc.perform(post("/api/accommodations")
+        mockMvc.perform(post("/backoffice-api/accommodations")
                 .content(objectMapper.writeValueAsString(request))
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(restDoc.document(
@@ -388,7 +380,7 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
             .willReturn(accommodationOwnershipResponse);
 
         // when then
-        mockMvc.perform(get("/api/accommodations/backoffice"))
+        mockMvc.perform(get("/backoffice-api/accommodations"))
             .andDo(restDoc.document(
                 responseFields().and(
                     fieldWithPath("accommodations").type(JsonFieldType.ARRAY)
@@ -401,81 +393,5 @@ public class AccommodationControllerDocsTest extends RestDocsSupport {
             ));
 
         verify(accommodationCommandService, times(1)).getAccommodationOwnership(any(Long.TYPE));
-    }
-
-    @Test
-    @DisplayName("이미지를 저장할 수 있다.")
-    @WithMockUser(roles = "ADMIN")
-    void saveImages() throws Exception {
-        // given
-        URL resource = getClass().getResource("/images/image_sample.jpg");
-
-        List<ImageUrlResponse> urls = new ArrayList<>();
-        urls.add(ImageUrlResponse.builder()
-            .url("https://aws/coupons/images/001")
-            .build());
-        urls.add(ImageUrlResponse.builder()
-            .url("https://aws/coupons/images/002")
-            .build());
-        urls.add(ImageUrlResponse.builder()
-            .url("https://aws/coupons/images/003")
-            .build());
-        urls.add(ImageUrlResponse.builder()
-            .url("https://aws/coupons/images/004")
-            .build());
-        ImageResponse imageResponse = ImageResponse.builder()
-            .urls(urls)
-            .build();
-
-        given(accommodationCommandService.saveImages(any(List.class)))
-            .willReturn(imageResponse);
-
-        // when then
-        mockMvc.perform(multipart("/api/accommodations/images")
-                .file(new MockMultipartFile(
-                    "image1",
-                    "image_sample.jpg",
-                    "images/png",
-                    resource.openStream().readAllBytes()
-                ))
-                .file(new MockMultipartFile(
-                    "image2",
-                    "image_sample.jpg",
-                    "images/png",
-                    resource.openStream().readAllBytes()
-                ))
-                .file(new MockMultipartFile(
-                    "image3",
-                    "image_sample.jpg",
-                    "images/png",
-                    resource.openStream().readAllBytes()
-                ))
-                .file(new MockMultipartFile(
-                    "image4",
-                    "image_sample.jpg",
-                    "images/png",
-                    resource.openStream().readAllBytes()
-                ))
-                .file(new MockMultipartFile(
-                    "image5",
-                    new byte[0]
-                )))
-            .andDo(restDoc.document(
-                requestParts(
-                    partWithName("image1").description("저장할 이미지 1"),
-                    partWithName("image2").description("저장할 이미지 2"),
-                    partWithName("image3").description("저장할 이미지 3"),
-                    partWithName("image4").description("저장할 이미지 4"),
-                    partWithName("image5").description("저장할 이미지 5")
-                ),
-                responseFields().and(
-                    fieldWithPath("urls").type(JsonFieldType.ARRAY)
-                        .description("이미지 URL 배열"),
-                    fieldWithPath("urls[].url").type(JsonFieldType.STRING).optional()
-                        .description("이미지 URL")
-                )
-            ));
-
-        verify(accommodationCommandService, times(1)).saveImages(any(List.class));
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/ImageControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/docs/ImageControllerDocsTest.java
@@ -1,0 +1,109 @@
+package com.backoffice.upjuyanolja.domain.accommodation.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageUrlResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.ImageService;
+import com.backoffice.upjuyanolja.global.util.RestDocsSupport;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+public class ImageControllerDocsTest extends RestDocsSupport {
+
+    @MockBean
+    private ImageService imageService;
+
+    @Test
+    @DisplayName("이미지를 저장할 수 있다.")
+    @WithMockUser(roles = "ADMIN")
+    void saveImages() throws Exception {
+        // given
+        URL resource = getClass().getResource("/images/image_sample.jpg");
+
+        List<ImageUrlResponse> urls = new ArrayList<>();
+        urls.add(ImageUrlResponse.builder()
+            .url("https://aws/coupons/images/001")
+            .build());
+        urls.add(ImageUrlResponse.builder()
+            .url("https://aws/coupons/images/002")
+            .build());
+        urls.add(ImageUrlResponse.builder()
+            .url("https://aws/coupons/images/003")
+            .build());
+        urls.add(ImageUrlResponse.builder()
+            .url("https://aws/coupons/images/004")
+            .build());
+        ImageResponse imageResponse = ImageResponse.builder()
+            .urls(urls)
+            .build();
+
+        given(imageService.saveImages(any(List.class)))
+            .willReturn(imageResponse);
+
+        // when then
+        mockMvc.perform(multipart("/backoffice-api/images")
+                .file(new MockMultipartFile(
+                    "image1",
+                    "image_sample.jpg",
+                    "images/png",
+                    resource.openStream().readAllBytes()
+                ))
+                .file(new MockMultipartFile(
+                    "image2",
+                    "image_sample.jpg",
+                    "images/png",
+                    resource.openStream().readAllBytes()
+                ))
+                .file(new MockMultipartFile(
+                    "image3",
+                    "image_sample.jpg",
+                    "images/png",
+                    resource.openStream().readAllBytes()
+                ))
+                .file(new MockMultipartFile(
+                    "image4",
+                    "image_sample.jpg",
+                    "images/png",
+                    resource.openStream().readAllBytes()
+                ))
+                .file(new MockMultipartFile(
+                    "image5",
+                    new byte[0]
+                )))
+            .andDo(restDoc.document(
+                requestParts(
+                    partWithName("image1").description("저장할 이미지 1"),
+                    partWithName("image2").description("저장할 이미지 2"),
+                    partWithName("image3").description("저장할 이미지 3"),
+                    partWithName("image4").description("저장할 이미지 4"),
+                    partWithName("image5").description("저장할 이미지 5")
+                ),
+                responseFields().and(
+                    fieldWithPath("urls").type(JsonFieldType.ARRAY)
+                        .description("이미지 URL 배열"),
+                    fieldWithPath("urls[].url").type(JsonFieldType.STRING).optional()
+                        .description("이미지 URL")
+                )
+            ));
+
+        verify(imageService, times(1)).saveImages(any(List.class));
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/ImageControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/controller/ImageControllerTest.java
@@ -1,0 +1,124 @@
+package com.backoffice.upjuyanolja.domain.accommodation.unit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.backoffice.upjuyanolja.domain.accommodation.controller.ImageController;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageUrlResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.ImageService;
+import com.backoffice.upjuyanolja.global.security.AuthenticationConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.catalina.security.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(value = ImageController.class,
+    excludeFilters = {@ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        SecurityConfig.class,
+        AuthenticationConfig.class})},
+    excludeAutoConfiguration = SecurityAutoConfiguration.class)
+public class ImageControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    private ImageService imageService;
+
+    @Nested
+    @DisplayName("saveImage()은")
+    class Context_saveImage {
+
+        @Test
+        @DisplayName("이미지를 저장할 수 있다.")
+        void _willSuccess() throws Exception {
+            // given
+            URL resource = getClass().getResource("/images/image_sample.jpg");
+
+            List<ImageUrlResponse> urls = new ArrayList<>();
+            urls.add(ImageUrlResponse.builder()
+                .url("https://aws/coupons/images/001")
+                .build());
+            urls.add(ImageUrlResponse.builder()
+                .url("https://aws/coupons/images/002")
+                .build());
+            urls.add(ImageUrlResponse.builder()
+                .url("https://aws/coupons/images/003")
+                .build());
+            urls.add(ImageUrlResponse.builder()
+                .url("https://aws/coupons/images/004")
+                .build());
+            ImageResponse imageResponse = ImageResponse.builder()
+                .urls(urls)
+                .build();
+
+            given(imageService.saveImages(any(List.class)))
+                .willReturn(imageResponse);
+
+            // when then
+            mockMvc.perform(multipart("/backoffice-api/images")
+                    .file(new MockMultipartFile(
+                        "image1",
+                        "image_sample.jpg",
+                        "images/png",
+                        resource.openStream().readAllBytes()
+                    ))
+                    .file(new MockMultipartFile(
+                        "image2",
+                        "image_sample.jpg",
+                        "images/png",
+                        resource.openStream().readAllBytes()
+                    ))
+                    .file(new MockMultipartFile(
+                        "image3",
+                        "image_sample.jpg",
+                        "images/png",
+                        resource.openStream().readAllBytes()
+                    ))
+                    .file(new MockMultipartFile(
+                        "image4",
+                        "image_sample.jpg",
+                        "images/png",
+                        resource.openStream().readAllBytes()
+                    ))
+                    .file(new MockMultipartFile(
+                        "image5"
+                        , new byte[0])
+                    ))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.urls").isArray())
+                .andExpect(jsonPath("$.urls[0].url").isString())
+                .andExpect(jsonPath("$.urls[1].url").isString())
+                .andExpect(jsonPath("$.urls[2].url").isString())
+                .andExpect(jsonPath("$.urls[3].url").isString())
+                .andExpect(jsonPath("$.urls[4].url").doesNotExist())
+                .andDo(print());
+
+            verify(imageService, times(1)).saveImages(any(List.class));
+        }
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/AccommodationCommandServiceTest.java
@@ -10,7 +10,6 @@ import com.backoffice.upjuyanolja.domain.accommodation.dto.request.Accommodation
 import com.backoffice.upjuyanolja.domain.accommodation.dto.request.AccommodationRegisterRequest;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationInfoResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.dto.response.AccommodationOwnershipResponse;
-import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationImage;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
@@ -18,7 +17,6 @@ import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOwner
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Address;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Category;
 import com.backoffice.upjuyanolja.domain.accommodation.service.AccommodationCommandService;
-import com.backoffice.upjuyanolja.domain.accommodation.service.S3UploadService;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationQueryUseCase;
 import com.backoffice.upjuyanolja.domain.accommodation.service.usecase.AccommodationQueryUseCase.AccommodationSaveRequest;
 import com.backoffice.upjuyanolja.domain.member.entity.Authority;
@@ -36,9 +34,6 @@ import com.backoffice.upjuyanolja.domain.room.entity.RoomPrice;
 import com.backoffice.upjuyanolja.domain.room.entity.RoomStatus;
 import com.backoffice.upjuyanolja.domain.room.service.RoomCommandService;
 import jakarta.persistence.EntityManager;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.URL;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,9 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @ExtendWith(MockitoExtension.class)
@@ -68,9 +61,6 @@ public class AccommodationCommandServiceTest {
 
     @Mock
     private RoomCommandService roomCommandService;
-
-    @Mock
-    private S3UploadService s3UploadService;
 
     @Mock
     private EntityManager em;
@@ -395,64 +385,6 @@ public class AccommodationCommandServiceTest {
             assertThat(result.accommodations().size()).isEqualTo(1);
             assertThat(result.accommodations().get(0).id()).isEqualTo(1L);
             assertThat(result.accommodations().get(0).name()).isEqualTo("그랜드 하얏트 제주");
-        }
-    }
-
-    @Nested
-    @DisplayName("saveImages()은")
-    class Context_saveImages {
-
-        @Test
-        @DisplayName("이미지를 저장할 수 있다.")
-        void _willSuccess() throws IOException {
-            // given
-            URL resource = getClass().getResource("/images/image_sample.jpg");
-            List<MultipartFile> imageFiles = new ArrayList<>();
-            imageFiles.add(new MockMultipartFile(
-                "image1",
-                "image_sample.jpg",
-                "images/png",
-                new FileInputStream(resource.getFile())
-            ));
-            imageFiles.add(new MockMultipartFile(
-                "image2",
-                "image_sample.jpg",
-                "images/png",
-                new FileInputStream(resource.getFile())
-            ));
-            imageFiles.add(new MockMultipartFile(
-                "image3",
-                "image_sample.jpg",
-                "images/png",
-                new FileInputStream(resource.getFile())
-            ));
-            imageFiles.add(new MockMultipartFile(
-                "image4",
-                "image_sample.jpg",
-                "images/png",
-                new FileInputStream(resource.getFile())
-            ));
-            imageFiles.add((new MockMultipartFile(
-                "image5"
-                , new byte[0])
-            ));
-
-            given(s3UploadService.saveFile(any(MockMultipartFile.class)))
-                .willReturn("https://aws/coupons/images/001");
-
-            // when
-            ImageResponse imageResponse = accommodationCommandService.saveImages(imageFiles);
-
-            assertThat(imageResponse.urls()).isNotEmpty();
-            assertThat(imageResponse.urls().get(0).url())
-                .isEqualTo("https://aws/coupons/images/001");
-            assertThat(imageResponse.urls().get(1).url())
-                .isEqualTo("https://aws/coupons/images/001");
-            assertThat(imageResponse.urls().get(2).url())
-                .isEqualTo("https://aws/coupons/images/001");
-            assertThat(imageResponse.urls().get(3).url())
-                .isEqualTo("https://aws/coupons/images/001");
-            assertThat(imageResponse.urls().get(4).url()).isNull();
         }
     }
 }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/ImageServiceTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/accommodation/unit/service/ImageServiceTest.java
@@ -1,0 +1,93 @@
+package com.backoffice.upjuyanolja.domain.accommodation.unit.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.backoffice.upjuyanolja.domain.accommodation.dto.response.ImageResponse;
+import com.backoffice.upjuyanolja.domain.accommodation.service.ImageService;
+import com.backoffice.upjuyanolja.domain.accommodation.service.S3UploadService;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+public class ImageServiceTest {
+
+    @InjectMocks
+    private ImageService imageService;
+
+    @Mock
+    private S3UploadService s3UploadService;
+
+    @Nested
+    @DisplayName("saveImages()은")
+    class Context_saveImages {
+
+        @Test
+        @DisplayName("이미지를 저장할 수 있다.")
+        void _willSuccess() throws IOException {
+            // given
+            URL resource = getClass().getResource("/images/image_sample.jpg");
+            List<MultipartFile> imageFiles = new ArrayList<>();
+            imageFiles.add(new MockMultipartFile(
+                "image1",
+                "image_sample.jpg",
+                "images/png",
+                new FileInputStream(resource.getFile())
+            ));
+            imageFiles.add(new MockMultipartFile(
+                "image2",
+                "image_sample.jpg",
+                "images/png",
+                new FileInputStream(resource.getFile())
+            ));
+            imageFiles.add(new MockMultipartFile(
+                "image3",
+                "image_sample.jpg",
+                "images/png",
+                new FileInputStream(resource.getFile())
+            ));
+            imageFiles.add(new MockMultipartFile(
+                "image4",
+                "image_sample.jpg",
+                "images/png",
+                new FileInputStream(resource.getFile())
+            ));
+            imageFiles.add((new MockMultipartFile(
+                "image5"
+                , new byte[0])
+            ));
+
+            given(s3UploadService.saveFile(any(MockMultipartFile.class)))
+                .willReturn("https://aws/coupons/images/001");
+
+            // when
+            ImageResponse imageResponse = imageService.saveImages(imageFiles);
+
+            assertThat(imageResponse.urls()).isNotEmpty();
+            assertThat(imageResponse.urls().get(0).url())
+                .isEqualTo("https://aws/coupons/images/001");
+            assertThat(imageResponse.urls().get(1).url())
+                .isEqualTo("https://aws/coupons/images/001");
+            assertThat(imageResponse.urls().get(2).url())
+                .isEqualTo("https://aws/coupons/images/001");
+            assertThat(imageResponse.urls().get(3).url())
+                .isEqualTo("https://aws/coupons/images/001");
+            assertThat(imageResponse.urls().get(4).url()).isNull();
+        }
+    }
+}

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/docs/RoomControllerDocsTest.java
@@ -113,7 +113,7 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .willReturn(roomInfoResponse);
 
         // when then
-        mockMvc.perform(post("/api/rooms/{accommodationId}", 1L)
+        mockMvc.perform(post("/backoffice-api/accommodations/{accommodationId}/rooms", 1L)
                 .content(objectMapper.writeValueAsString(request))
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(restDoc.document(
@@ -268,7 +268,7 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .willReturn(roomPageResponse);
 
         // when then
-        mockMvc.perform(get("/api/rooms/list/{accommodationId}", 1L)
+        mockMvc.perform(get("/backoffice-api/accommodations/{accommodationId}/rooms", 1L)
                 .queryParam("pageNum", "0")
                 .queryParam("pageSize", "10"))
             .andDo(restDoc.document(
@@ -373,9 +373,12 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .willReturn(roomInfoResponse);
 
         // when then
-        mockMvc.perform(get("/api/rooms/{roomId}", 1L))
+        mockMvc.perform(get("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                1L,
+                1L))
             .andDo(restDoc.document(
                 pathParameters(
+                    parameterWithName("accommodationId").description("조회할 객실이 속한 숙소 식별자"),
                     parameterWithName("roomId").description("조회할 객실 식별자")
                 ),
                 responseFields(
@@ -472,11 +475,14 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .willReturn(roomInfoResponse);
 
         // when then
-        mockMvc.perform(put("/api/rooms/{roomId}", 1L)
+        mockMvc.perform(put("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                1L,
+                1L)
                 .content(objectMapper.writeValueAsString(request))
                 .contentType(MediaType.APPLICATION_JSON))
             .andDo(restDoc.document(
                 pathParameters(
+                    parameterWithName("accommodationId").description("수정할 객실이 속한 숙소 식별자"),
                     parameterWithName("roomId").description("수정할 객실 식별자")
                 ),
                 requestFields(
@@ -608,9 +614,12 @@ public class RoomControllerDocsTest extends RestDocsSupport {
             .willReturn(roomInfoResponse);
 
         // when then
-        mockMvc.perform(delete("/api/rooms/{roomId}", 1L))
+        mockMvc.perform(delete("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                1L,
+                1L))
             .andDo(restDoc.document(
                 pathParameters(
+                    parameterWithName("accommodationId").description("삭제할 객실이 속한 숙소 식별자"),
                     parameterWithName("roomId").description("삭제할 객실 식별자")
                 ),
                 responseFields(

--- a/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/room/unit/controller/RoomControllerTest.java
@@ -118,7 +118,7 @@ public class RoomControllerTest {
                 .willReturn(roomInfoResponse);
 
             // when then
-            mockMvc.perform(post("/api/rooms/{accommodationId}", 1L)
+            mockMvc.perform(post("/backoffice-api/accommodations/{accommodationId}/rooms", 1L)
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
@@ -207,7 +207,7 @@ public class RoomControllerTest {
                 .willReturn(roomPageResponse);
 
             // when then
-            mockMvc.perform(get("/api/rooms/list/{accommodationId}", 1L)
+            mockMvc.perform(get("/backoffice-api/accommodations/{accommodationId}/rooms", 1L)
                     .queryParam("pageNum", "0")
                     .queryParam("pageSize", "10"))
                 .andExpect(status().isOk())
@@ -279,7 +279,9 @@ public class RoomControllerTest {
                 .willReturn(roomInfoResponse);
 
             // when then
-            mockMvc.perform(get("/api/rooms/{accommodationId}", 1L))
+            mockMvc.perform(get("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                    1L,
+                    1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNumber())
                 .andExpect(jsonPath("$.name").isString())
@@ -360,7 +362,9 @@ public class RoomControllerTest {
                 .willReturn(roomInfoResponse);
 
             // when then
-            mockMvc.perform(put("/api/rooms/{roomId}", 1L)
+            mockMvc.perform(put("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                    1L,
+                    1L)
                     .content(objectMapper.writeValueAsString(request))
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -421,7 +425,10 @@ public class RoomControllerTest {
                 .willReturn(roomInfoResponse);
 
             // when then
-            mockMvc.perform(delete("/api/rooms/{accommodationId}", 1L))
+            mockMvc.perform(
+                    delete("/backoffice-api/accommodations/{accommodationId}/rooms/{roomId}",
+                        1L,
+                        1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").isNumber())
                 .andExpect(jsonPath("$.name").isString())


### PR DESCRIPTION
### 💡Motivation
- 중간 피드백으로 URI 설계에 대한 내용을 피드백 받았습니다!
- 피드백을 반영하며 숙소, 객실 관련 API URI를 수정하려고 합니다. 

#### 💬RESTfull 설계 피드백
- RESTful 설계시 collection 과 하위 경로의 unique resource의 관계와 일관성을 유지를 고려하여 설계해야 합니다. 
- RESTful API의 조회는 collection 목록을 받는 행위입니다. 따라서 list 라는 path는 필요하지 않습니다. 검색조건은 collection 에 대한 필터를 적용하는 것으로 고려하면 설계 방향이 뚜렷해집니다.
- backoffice 목적의 api 라면 딱 정해진 것은 아니지만, path 의 중간이 아닌 맨 앞에 정의하는 것이 라우팅, 업스트림, 스프링시큐리티 등의 설정에서 유리하고 논리적으로도 시각적으로도 낫습니다.

### 📌Changes
- 숙소 등록 API URI 수정: POST /backoffice-api/accommodations
- 보유 숙소 목록 조회 API URI 수정: GET /backoffice-api/accommodations

- 이미지 등록 API URI 수정: POST /backoffice-api/images

- 객실 등록 API URI 수정: POST /backoffice-api/accommodations/{accommodationId}/rooms
- 객실 목록 조회 API URI 수정: GET /backoffice-api/accommodations/{accommodationId}/rooms
- 객실 상세 조회 API URI 수정: GET /backoffice-api/accommodations/{accommodationId}/rooms/{roomId}
- 객실 수정 API URI 수정: PUT /backoffice-api/accommodations/{accommodationId}/rooms/{roomId}
- 객실 삭제 API URI 수정: DELETE /backoffice-api/accommodations/{accommodationId}/rooms/{roomId}
- 수정된 URI에 맞게 시큐리티 권한 설정 수정
- REST Docs adoc 파일 수정

### 🫱🏻‍🫲🏻To Reviewers
- 코드 리뷰 부탁 드립니다! 😊