### PR TITLE
삭제된 객실도 쿠폰 만들기에서 조회되는 버그 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/dto/response/backoffice/CouponMakeQueryDto.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/dto/response/backoffice/CouponMakeQueryDto.java
@@ -1,0 +1,13 @@
+package com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice;
+
+import lombok.Builder;
+
+@Builder
+public record CouponMakeQueryDto(
+    Long accommodationId,
+    String accommodationName,
+    Long roomId,
+    String roomName,
+    Integer roomPrice
+) {
+}

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/dto/response/backoffice/CouponMakeViewResponse.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/dto/response/backoffice/CouponMakeViewResponse.java
@@ -1,6 +1,7 @@
 package com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.Builder;
 
 @Builder
@@ -9,15 +10,20 @@ public record CouponMakeViewResponse(
     String accommodationName,
     List<CouponRoomsResponse> rooms
 ) {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CouponMakeViewResponse that = (CouponMakeViewResponse) o;
+        return Objects.equals(accommodationId, that.accommodationId);
+    }
 
-    public static CouponMakeViewResponse of(
-        AccommodationResponse accommodationResponse,
-        List<CouponRoomsResponse> roomListRespons
-    ) {
-        return CouponMakeViewResponse.builder()
-            .accommodationId(accommodationResponse.accommodationId())
-            .accommodationName(accommodationResponse.accommodationName())
-            .rooms(roomListRespons)
-            .build();
+    @Override
+    public int hashCode() {
+        return Objects.hash(accommodationId);
     }
 }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/entity/Coupon.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -110,8 +111,13 @@ public class Coupon extends BaseTime {
         this.stock -= quantity;
 
         if (stock == 0) {
-            setupDeleted();
+            setupSoldOut();
         }
+        return this;
+    }
+
+    private Coupon setupSoldOut() {
+        this.couponStatus = CouponStatus.SOLD_OUT;
         return this;
     }
 
@@ -132,16 +138,12 @@ public class Coupon extends BaseTime {
         return this;
     }
 
-    public Coupon setupDeleted() {
-        this.couponStatus = CouponStatus.DELETED;
-        return this;
+    @Override
+    public void delete(LocalDateTime currentTime) {
+        super.delete(currentTime);
     }
 
-    /**
-     * Grouping을 위한 hashCode & equals override. id로 같은 객체인지 비교.
-     * @param o
-     * @return
-     */
+    // Grouping을 위한 hashCode & equals override.
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/entity/CouponStatus.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/entity/CouponStatus.java
@@ -8,8 +8,7 @@ public enum CouponStatus {
 
     ENABLE("발급 중"),
     DISABLE("발급 중지"),
-    SOLD_OUT("소진"),
-    DELETED("삭제");
+    SOLD_OUT("소진");
 
     private final String description;
 
@@ -17,11 +16,8 @@ public enum CouponStatus {
         this.description = description;
     }
 
-    public static final Predicate<CouponStatus> isDeletedCoupon =
-        (status) -> status.equals(DELETED);
-
     public static final Predicate<CouponStatus> isRedeemCoupon = (status) -> {
-        if (status.equals(SOLD_OUT) || status.equals(DELETED)) {
+        if (status.equals(SOLD_OUT)) {
             return false;
         }
         return true;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/repository/CouponRepositoryCustom.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/repository/CouponRepositoryCustom.java
@@ -1,12 +1,12 @@
 package com.backoffice.upjuyanolja.domain.coupon.repository;
 
-import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponMakeViewResponse;
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponMakeQueryDto;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponManageQueryDto;
 import java.util.List;
 
 public interface CouponRepositoryCustom {
 
-    CouponMakeViewResponse findRoomsByAccommodationId(Long accommodationId);
+    List<CouponMakeQueryDto> findRoomsByAccommodationId(Long accommodationId);
 
     boolean existsAccommodationIdByMemberId(Long accommodationId, Long memberId);
 

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/repository/CouponStatisticsRepository.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/repository/CouponStatisticsRepository.java
@@ -9,26 +9,35 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CouponStatisticsRepository extends JpaRepository<CouponStatistics, Long> {
 
-    @Query(value =
-        "select t.id, "
-        + "       t.total, "
-        + "       u.used, "
-        + "       t.total - u.used   as stock "
-        + "from (select ac.id as id, sum(ci.quantity) as total "
-        + "      from coupon_issuance ci "
-        + "               join room rm on ci.room_id = rm.id "
-        + "               join accommodation ac on rm.accommodation_id = ac.id "
-        + "      group by ac.id) t "
-        + "         inner join "
-        + "     (select ac.id as id, count(*) as used "
-        + "      from reservation_room rr "
-        + "               left join reservation rv on rr.id = rv.reservation_room_id "
-        + "               left join coupon_redeem cr on rv.id = cr.reservation_id "
-        + "               left join room r on rr.room_id = r.ID "
-        + "               left join accommodation ac on r.accommodation_id = ac.id "
-        + "      where rv.is_coupon_used = true "
-        + "      group by ac.id) u "
-        + "     on t.id = u.id", nativeQuery = true)
+    String couponQuery = """
+        select t.id, t.total, u.used, t.total - u.used as stock
+        from (select ac.id as id, sum(ci.quantity) as total
+              from coupon_issuance ci
+                       left join room rm on ci.room_id = rm.id
+                       left join coupon cp on cp.id = ci.coupon_id
+                       left join accommodation ac on rm.accommodation_id = ac.id
+              where rm.deleted_at is null
+                and ac.deleted_at is null
+                and cp.deleted_at is null
+              group by ac.id) t
+                 inner join
+             (select ac.id as id, count(*) as used
+              from room rm
+                       left join reservation_room rr on rr.room_id = rm.id
+                       left join reservation rv on rr.id = rv.reservation_room_id
+                       left join coupon_redeem cr on rv.id = cr.reservation_id
+                       left join accommodation ac on rm.accommodation_id = ac.id
+              where rv.is_coupon_used = true
+                and rm.deleted_at is null
+                and ac.deleted_at is null
+                and not exists(select 1
+                               from coupon cp
+                                        inner join coupon_redeem cr on cr.coupon_id = cp.id
+                               where cp.deleted_at is not null)
+              group by ac.id) u
+             on t.id = u.id
+        """;
+    @Query(value = couponQuery, nativeQuery = true)
     List<CouponStatisticsInterface> createStatistics();
 
     Optional<CouponStatistics> findByAccommodationId(Long accommodationId);

--- a/src/test/java/com/backoffice/upjuyanolja/domain/coupon/docs/CouponBackofficeControllerDocsTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/coupon/docs/CouponBackofficeControllerDocsTest.java
@@ -1,8 +1,6 @@
 package com.backoffice.upjuyanolja.domain.coupon.docs;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -17,12 +15,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponStatisticsResponse;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Accommodation;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.AccommodationOption;
 import com.backoffice.upjuyanolja.domain.accommodation.entity.Address;
@@ -43,13 +38,13 @@ import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponMa
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponManageResponse;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponManageRooms;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponRoomsResponse;
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponStatisticsResponse;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.RevenueInfo;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.RevenueStatisticsResponse;
 import com.backoffice.upjuyanolja.domain.coupon.entity.Coupon;
 import com.backoffice.upjuyanolja.domain.coupon.entity.CouponStatus;
 import com.backoffice.upjuyanolja.domain.coupon.entity.CouponType;
 import com.backoffice.upjuyanolja.domain.coupon.entity.DiscountType;
-import com.backoffice.upjuyanolja.domain.coupon.entity.RevenueStatistics;
 import com.backoffice.upjuyanolja.domain.coupon.service.CouponBackofficeService;
 import com.backoffice.upjuyanolja.domain.coupon.service.CouponStatisticsService;
 import com.backoffice.upjuyanolja.domain.member.dto.response.MemberInfoResponse;
@@ -760,9 +755,7 @@ class CouponBackofficeControllerDocsTest extends RestDocsSupport {
             createCoupon(
                 couponIds.get(1), room, DiscountType.RATE, CouponStatus.ENABLE, 10, 20),
             createCoupon(
-                couponIds.get(2), room, DiscountType.FLAT, CouponStatus.SOLD_OUT, 1000, 0),
-            createCoupon(
-                couponIds.get(3), room, DiscountType.RATE, CouponStatus.DELETED, 30, 0)
+                couponIds.get(2), room, DiscountType.FLAT, CouponStatus.SOLD_OUT, 1000, 0)
         );
         return coupons;
     }

--- a/src/test/java/com/backoffice/upjuyanolja/domain/coupon/unit/repository/CouponRepositoryTest.java
+++ b/src/test/java/com/backoffice/upjuyanolja/domain/coupon/unit/repository/CouponRepositoryTest.java
@@ -17,6 +17,7 @@ import com.backoffice.upjuyanolja.domain.coupon.dto.request.backoffice.CouponAdd
 import com.backoffice.upjuyanolja.domain.coupon.dto.request.backoffice.CouponModifyInfos;
 import com.backoffice.upjuyanolja.domain.coupon.dto.request.backoffice.CouponModifyRequest;
 import com.backoffice.upjuyanolja.domain.coupon.dto.request.backoffice.CouponModifyRooms;
+import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponMakeQueryDto;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponMakeViewResponse;
 import com.backoffice.upjuyanolja.domain.coupon.dto.response.backoffice.CouponManageQueryDto;
 import com.backoffice.upjuyanolja.domain.coupon.entity.Coupon;
@@ -127,17 +128,12 @@ class CouponRepositoryTest {
         @DisplayName("View에 응답해줄 데이터를 테스트한다.")
         public void makeCouponTest() throws Exception {
             // given
-            CouponMakeViewResponse response = couponRepository
+            List<CouponMakeQueryDto> response = couponRepository
                 .findRoomsByAccommodationId(1L);
 
             // when& Then
-            assertThat(response.accommodationName()).isEqualTo("그랜드 하얏트 제주");
-            assertThat(response.rooms().size()).isEqualTo(3);
-            response.rooms().forEach(room -> {
-                assertThat(room.roomId()).isGreaterThan(0);
-                assertThat(room.roomName()).isNotBlank();
-                assertThat(room.roomPrice()).isNotNull();
-            });
+            assertThat(response.get(0).accommodationName()).isEqualTo("그랜드 하얏트 제주");
+            assertThat(response.size()).isEqualTo(3);
         }
 
         @DisplayName("업주의 id로 등록되어 있는 숙소가 있는지 검증한다.")
@@ -299,9 +295,7 @@ class CouponRepositoryTest {
             createCoupon(
                 couponIds.get(1), room, DiscountType.RATE, CouponStatus.ENABLE, 10, 20),
             createCoupon(
-                couponIds.get(2), room, DiscountType.FLAT, CouponStatus.SOLD_OUT, 1000, 0),
-            createCoupon(
-                couponIds.get(3), room, DiscountType.RATE, CouponStatus.DELETED, 30, 0)
+                couponIds.get(2), room, DiscountType.FLAT, CouponStatus.SOLD_OUT, 1000, 0)
         );
         couponRepository.saveAll(coupons);
         return coupons;


### PR DESCRIPTION
### 💡Motivation
- 객실 조회시 deleted_at 체크를 하지 않아 삭제된 객실도 쿠폰 만들기에서 조회되는 버그가 발생
- 쿠폰 관리에서도 삭제된 객실이 조회되는 버그가 발생

### 📌Changes
-  쿼리에 숙소 및 객실의 삭제 상태를 체크하는 로직 추가.
- 쿠폰 삭제 상태 체크로 마찬가지로 쿼리에서 체크하도록 수정.
- 쿠폰 삭제 상태 체크를 팀 코드에 맞춰서 기존의 Enum에서 DELETED로 체크하던 것을 deleted_at 컬럼의 null 여부로 체크하도록 로직 변경
- 로직 변경에 영향을 받은 테스트 코드 수정

### 🫱🏻‍🫲🏻To Reviewers
- 코드 리뷰 부탁 드립니다.