### PR TITLE
#217 fix: 통계 쿼리 호환성 버그 수정

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Configuration
 @RequiredArgsConstructor
 @Transactional
-@Profile("local")
+@Profile("prod")
 public class MockStatisticsInit {
 
     private final CouponStatisticsRepository couponStatisticsRepository;

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Configuration
 @RequiredArgsConstructor
 @Transactional
-@Profile("prod")
+@Profile("local")
 public class MockStatisticsInit {
 
     private final CouponStatisticsRepository couponStatisticsRepository;
@@ -49,7 +49,8 @@ public class MockStatisticsInit {
                 if (!couponStatisticsRepository.existsById(1L)) {
                     makeCouponStatistics();
                 }
-                if (!revenueStatisticsRepository.existsById(1L)) {
+                if (!revenueStatisticsRepository.existsById(1L) ||
+                    !revenueTotalRepository.existsById(1L)) {
                     createRevenueStatistics();
                 }
             }

--- a/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/coupon/config/MockStatisticsInit.java
@@ -49,7 +49,8 @@ public class MockStatisticsInit {
                 if (!couponStatisticsRepository.existsById(1L)) {
                     makeCouponStatistics();
                 }
-                if (!revenueStatisticsRepository.existsById(1L)) {
+                if (!revenueStatisticsRepository.existsById(1L) ||
+                    !revenueTotalRepository.existsById(1L)) {
                     createRevenueStatistics();
                 }
             }


### PR DESCRIPTION
### 💡Motivation
- 개발에서 사용하던 H2 DB와 AWS RDS에서 사용하는 Maria DB간의 쿼리 호환성 문제로 인하여 통계 쿼리가 정상 작동하지 않는 문제 수정

### 📌Changes
- Group by시 시분초까지 구분하여  group by 하는 문제를 날짜 단위로만 group by 할 수 있도록 수정
- 쿠폰 통계에서 N -> 1방향으로 조인 하던 것을 1-> N 방향으로 조인하도록 수정.
- 삭제된 쿠폰과 예약 취소건을 통계에 포함하지 않도록 수정.

### 🫱🏻‍🫲🏻To Reviewers
- 리뷰 부탁 드립니다. 

Closes #217 
