### PR TITLE
fix: 쿠폰 재고 감소 시 누락된 숙소 재고 보상 트랜젝션 추가

### DIFF
--- a/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/backoffice/upjuyanolja/domain/reservation/service/ReservationService.java
@@ -84,7 +84,13 @@ public class ReservationService {
          * 쿠폰 재고 차감
          * */
         if (coupon != null) {
-            stockService.decreaseCouponStock(coupon.getId()); //lock
+            try {
+                stockService.decreaseCouponStock(coupon.getId()); //lock
+            } catch (Exception e) {
+                for (RoomStock roomStock : roomStocks) {
+                    stockService.increaseRoomStock(roomStock.getId()); //lock
+                }
+            }
         }
 
         /*


### PR DESCRIPTION
### 💡Motivation
쿠폰 재고 감소 예외처리가 누락된 것을 확인했습니다. 
예외 발생 시 숙소 재고 보상 트랜젝션을 수행하도록 수정해야합니다. 

### 📌Changes
- 쿠폰 재고 감소 시 예외처리 

### 🫱🏻‍🫲🏻To Reviewers
